### PR TITLE
Added driver suport for 396.54

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -37,6 +37,7 @@ declare -A patch_list=(
     ["396.37"]='s/\x85\xC0\x89\xC5\x0F\x85\x96\x00\x00\x00/\x29\xC0\x89\xC5\x90\x90\x90\x90\x90\x90/g' #added info from https://github.com/keylase/nvidia-patch/issues/6#issuecomment-406895356
     # break nvenc.c:236,layout asm,step-mode,step,break *0x00007fff89f9ba45
     # libnvidia-encode.so @ 0x15a45; test->sub, jne->nop-nop-nop-nop-nop-nop
+    ["396.54"]='s/\x85\xC0\x89\xC5\x0F\x85\x96\x00\x00\x00/\x29\xC0\x89\xC5\x90\x90\x90\x90\x90\x90/g'
 )
 
 driver_version=$(/usr/bin/nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits | head -n 1)


### PR DESCRIPTION
Adding suport for 396.54
Using gtx 970 and Ubuntu 18.04 with kernel  4.18.7
Tested with plex tranconder
![screenshot from 2018-09-14 18-58-08](https://user-images.githubusercontent.com/4356041/45577118-ccf06080-b850-11e8-9b88-97dc896dbef7.png)
![screenshot from 2018-09-14 18-58-26](https://user-images.githubusercontent.com/4356041/45577123-cf52ba80-b850-11e8-8bc4-61cae111e02f.png)
