### PR TITLE
README: country agnostic URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Requirements:
 - ubuntu (< 18.04 for 375.39 nvidia driver or kernel < 4.15)
 - nvenc-compatible gpu (https://developer.nvidia.com/video-encode-decode-gpu-support-matrix#Encoder)
 - nvidia driver. Patch availible for: 
-  - 375.39 - http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run
-  - 390.87 - http://us.download.nvidia.com/XFree86/Linux-x86_64/390.87/NVIDIA-Linux-x86_64-390.87.run
-  - 396.24 - http://us.download.nvidia.com/XFree86/Linux-x86_64/396.24/NVIDIA-Linux-x86_64-396.24.run
-  - 396.26 - http://us.download.nvidia.com/XFree86/Linux-x86_64/396.26/NVIDIA-Linux-x86_64-396.26.run
-  - 396.37 - http://us.download.nvidia.com/XFree86/Linux-x86_64/396.37/NVIDIA-Linux-x86_64-396.37.run
-  - 396.54 - http://us.download.nvidia.com/XFree86/Linux-x86_64/396.54/NVIDIA-Linux-x86_64-396.54.run
-  - 410.48 - http://us.download.nvidia.com/XFree86/Linux-x86_64/410.48/NVIDIA-Linux-x86_64-410.48.run
-  - 410.57 - http://us.download.nvidia.com/XFree86/Linux-x86_64/410.57/NVIDIA-Linux-x86_64-410.57.run
-  - 410.73 - http://us.download.nvidia.com/XFree86/Linux-x86_64/410.73/NVIDIA-Linux-x86_64-410.73.run
-  - 410.78 - http://us.download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
+  - 375.39 - http://download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run
+  - 390.87 - http://download.nvidia.com/XFree86/Linux-x86_64/390.87/NVIDIA-Linux-x86_64-390.87.run
+  - 396.24 - http://download.nvidia.com/XFree86/Linux-x86_64/396.24/NVIDIA-Linux-x86_64-396.24.run
+  - 396.26 - http://download.nvidia.com/XFree86/Linux-x86_64/396.26/NVIDIA-Linux-x86_64-396.26.run
+  - 396.37 - http://download.nvidia.com/XFree86/Linux-x86_64/396.37/NVIDIA-Linux-x86_64-396.37.run
+  - 396.54 - http://download.nvidia.com/XFree86/Linux-x86_64/396.54/NVIDIA-Linux-x86_64-396.54.run
+  - 410.48 - http://download.nvidia.com/XFree86/Linux-x86_64/410.48/NVIDIA-Linux-x86_64-410.48.run
+  - 410.57 - http://download.nvidia.com/XFree86/Linux-x86_64/410.57/NVIDIA-Linux-x86_64-410.57.run
+  - 410.73 - http://download.nvidia.com/XFree86/Linux-x86_64/410.73/NVIDIA-Linux-x86_64-410.73.run
+  - 410.78 - http://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
 
 
 Tested on Ubuntu 18.04 LTS (GNU/Linux 4.15.0-23-generic x86_64)
@@ -23,12 +23,12 @@ Tested on Ubuntu 18.04 LTS (GNU/Linux 4.15.0-23-generic x86_64)
 ## step-by-step :
 
 ### Download driver
-http://us.download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
+http://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
 
 ### Install driver (410.78)
 ```bash
 mkdir /opt/nvidia && cd /opt/nvidia
-wget http://us.download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
+wget http://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run
 chmod +x ./NVIDIA-Linux-x86_64-410.78.run
 ./NVIDIA-Linux-x86_64-410.78.run
 ```


### PR DESCRIPTION
**Purpose of proposed changes**

Fixes issue #18

**Essential steps taken**

New URLs has been checked using `curl` and replaced in README. Some of links (versions 396.26 and 396.37) returning HTTP 404, but same behavior takes place with old URLs too.