### PR TITLE
Results of shellcheck hunt

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -89,25 +89,25 @@ if [[ ( ! "$patch" ) ||  ( ! "$object" ) ]]; then
 fi
 
 if [[ $rollback_flag ]]; then
-    if [[ -f $backup_path/"$object".$driver_version ]]; then
-        cp -p $backup_path/"$object".$driver_version \
-           $driver_dir/"$object".$driver_version
+    if [[ -f "$backup_path/$object.$driver_version" ]]; then
+        cp -p "$backup_path/$object.$driver_version" \
+           "$driver_dir/$object.$driver_version"
         echo "Restore from backup $object.$driver_version"
     else
         echo "Backup not found. Try to patch first."
         exit 1;
     fi
 else
-    if [[ ! -f $backup_path/"$object".$driver_version ]]; then
-        echo "Attention! Backup not found. Copy current libnvidia-encode to backup."
-        mkdir -p $backup_path
-        cp -p $driver_dir/"$object".$driver_version \
-           $backup_path/"$object".$driver_version
+    if [[ ! -f "$backup_path/$object.$driver_version" ]]; then
+        echo "Attention! Backup not found. Copy current $object to backup."
+        mkdir -p "$backup_path"
+        cp -p "$driver_dir/$object.$driver_version" \
+           "$backup_path/$object.$driver_version"
     fi
-    sha1sum $backup_path/"$object".$driver_version
-    sed "$patch" $backup_path/"$object".$driver_version > \
-      $driver_dir/"$object".$driver_version
-    sha1sum $driver_dir/"$object".$driver_version
+    sha1sum "$backup_path/$object.$driver_version"
+    sed "$patch" "$backup_path/$object.$driver_version" > \
+      "$driver_dir/$object.$driver_version"
+    sha1sum "$driver_dir/$object.$driver_version"
     ldconfig
     echo "Patched!"
 fi


### PR DESCRIPTION
**Purpose of proposed changes**

* Fixes bug: message 'Something went wrong. Check nvidia driver' never displayed because `$?` always zero due to pipe containing last `head` which always succeeds.
* Fix: https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing
* Fix: https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with
* Introduces strict mode of BASH operation:
  * Fail and exit on any undefined variables
  * Fail and exit on command errors
  * Fail pipes if any command in pipe fails (it was essential for `nvidia-smi` pipe)

General purpose of changes made is to make code safer to run and eliminate possibility of unexpected behavior.

**Essential steps taken**

Linted code with latest stable `shellcheck`, located potential and actual issues.