### PR TITLE
Guard from CRLF newlines

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-
-set -euo pipefail
+# halt on any error for safety and proper pipe handling
+set -euo pipefail ; # <- this semicolon and comment make options apply
+# even when script is corrupt by CRLF line terminators (issue #75)
+# empty line must follow this comment for immediate fail with CRLF newlines
 
 backup_path="/opt/nvidia/libnvidia-encode-backup"
 silent_flag=''


### PR DESCRIPTION
**Purpose of proposed changes**

Our script for linux already works safely and halts on all errors. But sometimes user may spoil file with CRLF newlines (#75) and `pipefail` option is not applied then. This change ensures all interpreter options applied and script is failing safely in this case.

**Essential steps taken**

Edit.