### PR TITLE
Add driver location directory for Debian 9 using nvidia-current driver

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -106,7 +106,8 @@ object="${object_list[$driver_version]}"
 
 declare -a driver_locations=(
     '/usr/lib/x86_64-linux-gnu'
-    '/usr/lib64'
+    '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+	'/usr/lib64'
     "/usr/lib/nvidia-${driver_version%%.*}"
 )
 

--- a/patch.sh
+++ b/patch.sh
@@ -105,10 +105,10 @@ patch="${patch_list[$driver_version]}"
 object="${object_list[$driver_version]}"
 
 declare -a driver_locations=(
-    '/usr/lib/x86_64-linux-gnu'
-    '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+	'/usr/lib/x86_64-linux-gnu'
+	'/usr/lib/x86_64-linux-gnu/nvidia/current/'
 	'/usr/lib64'
-    "/usr/lib/nvidia-${driver_version%%.*}"
+	"/usr/lib/nvidia-${driver_version%%.*}"
 )
 
 dir_found=''

--- a/patch.sh
+++ b/patch.sh
@@ -105,10 +105,10 @@ patch="${patch_list[$driver_version]}"
 object="${object_list[$driver_version]}"
 
 declare -a driver_locations=(
-	'/usr/lib/x86_64-linux-gnu'
-	'/usr/lib/x86_64-linux-gnu/nvidia/current/'
-	'/usr/lib64'
-	"/usr/lib/nvidia-${driver_version%%.*}"
+    '/usr/lib/x86_64-linux-gnu'
+    '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+    '/usr/lib64'
+    "/usr/lib/nvidia-${driver_version%%.*}"
 )
 
 dir_found=''


### PR DESCRIPTION
I tried using `bash ./patch.sh` to patch my Nvidia driver. I kept getting the `ERROR: cannot detect driver directory` error even though I had made sure I installed the Nvidia drivers correctly. After checking the [file list](https://packages.debian.org/stretch/amd64/libnvidia-encode1/filelist) for the `libnvidia-encode1` package, I saw that the driver locations that get checked by `patch.sh` were missing the directory for the `nvidia-current` driver on Debian 9.

Adding the missing directory to the list of directories fixes this issue and the patch succeeds.