### PR TITLE
nv-driver-locator: add support for Windows Server drivers

### DIFF
--- a/tools/nv-driver-locator/README.md
+++ b/tools/nv-driver-locator/README.md
@@ -263,7 +263,7 @@ Type: `nvidia_downloads`
 
 Params:
 
-* `os` - OS family, version and bitness. Allowed values: `Linux_32`, `Linux_64`, `Windows7_32`, `Windows7_64`, `Windows10_32`, `Windows10_64`. Default: `Linux_64`.
+* `os` - OS family, version and bitness. Allowed values: `Linux_32`, `Linux_64`, `Windows7_32`, `Windows7_64`, `Windows10_32`, `Windows10_64`, `WindowsServer2012R2_32`, `WindowsServer2012R2_64`. Default: `Linux_64`.
 * `product` - product kind. Allowed values: `GeForce`, `GeForceMobile`, `Quadro`, `QuadroMobile`. Default: `GeForce`.
 * `certlevel` - driver certification level. Allowed values: `All` - any certification level, `Beta` - beta drivers, `Certified` - WHQL certified in Windows case and Nvidia certified in Linux case, `ODE` - Optimal Driver for Enterprise (Quadro driver), `QNF` - Quadro New Feature (Quadro driver). Default: `All`.
 * `driver_type` - driver type. Allowed values: `Standard`, `DCH`. At this moment DCH driver appears to exists only for some product families and only for Windows 10 x64. Default: `Standard`.

--- a/tools/nv-driver-locator/get_nvidia_downloads.py
+++ b/tools/nv-driver-locator/get_nvidia_downloads.py
@@ -19,6 +19,8 @@ class OS(enum.Enum):
     Windows7_64 = 19
     Windows10_32 = 56
     Windows10_64 = 57
+    WindowsServer2012R2_32 = 32
+    WindowsServer2012R2_64 = 44
 
     def __str__(self):
         return self.name

--- a/tools/nv-driver-locator/nv-driver-locator.json.sample
+++ b/tools/nv-driver-locator/nv-driver-locator.json.sample
@@ -166,6 +166,15 @@
                 "product": "QuadroMobile",
                 "certlevel": "All"
             }
+        },
+        {
+            "type": "nvidia_downloads",
+            "name": "downloads win server quadro certified",
+            "params": {
+                "os": "WindowsServer2012R2_64",
+                "product": "Quadro",
+                "certlevel": "Certified"
+            }
         }
     ],
     "notifiers": [


### PR DESCRIPTION
**Purpose of proposed changes**

Related to #108 

Introduces support for Windows Server 2012R2 in nvidia-driver-locator

**Essential steps taken**

New enum valued, updated doc and sample config.
