### PR TITLE
autopatch: change prefix for studio driver

### DIFF
--- a/win/tools/autopatch/autopatch.py
+++ b/win/tools/autopatch/autopatch.py
@@ -166,7 +166,7 @@ def main():
         drv_prefix = {
             "100": "quadro_",
             "300": "",
-            "301": "crd_",
+            "301": "nsd_",
         }
         installer_basename = os.path.basename(args.installer_file)
         os_prefix = ('ws2012_x64' if 'winserv' in installer_basename.lower()


### PR DESCRIPTION
**Purpose of proposed changes**

Change directory prefix created by autopatch tool to reflect latest rename of CreatorReady Driver to Studio Driver.

**Essential steps taken**

Fix
