### PR TITLE
ndl: track tesla drivers as well

### DIFF
--- a/tools/nv-driver-locator/get_nvidia_downloads.py
+++ b/tools/nv-driver-locator/get_nvidia_downloads.py
@@ -56,6 +56,7 @@ class Product(enum.Enum):
     GeForceMobile = (111, 890)
     Quadro = (73, 844)
     QuadroMobile = (74, 875)
+    Tesla = (110, 883)
 
     def __str__(self):
         return self.name
@@ -91,6 +92,7 @@ class DriverLanguage(enum.Enum):
 class CUDAToolkitVersion(enum.Enum):
     Nothing = 0
     v10_0 = 20
+    v10_1 = 21
 
     def __str__(self):
         return self.name

--- a/tools/nv-driver-locator/nv-driver-locator.json.sample
+++ b/tools/nv-driver-locator/nv-driver-locator.json.sample
@@ -226,6 +226,15 @@
             }
         },
         {
+            "type": "nvidia_downloads",
+            "name": "downloads linux tesla all",
+            "params": {
+                "os": "Linux_64",
+                "product": "Tesla",
+                "certlevel": "All"
+            }
+        },
+        {
             "type": "cuda_downloads",
             "name": "cuda toolkit tracker",
             "params": {}


### PR DESCRIPTION
**Purpose of proposed changes**

Related to #169 

It seems Tesla driver along with CUDA Toolkit are often shipped by OEMs and package maintainers even for GeForce cards. Therefore these drivers are of interest for us as well.

**Essential steps taken**

Edit, test.