### PR TITLE
Add more descriptive info about driver version detection failure #267

### DIFF
--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -111,8 +111,15 @@ patch_common () {
         exit 1
     fi
 
-    if ! driver_version=$("$NVIDIA_SMI" --query-gpu=driver_version --format=csv,noheader,nounits | head -n 1) ; then
-        echo 'Something went wrong. Check nvidia driver'
+    cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
+    driver_versions_list=$($cmd)
+    ret_code=$?
+    driver_version=$(echo "$driver_versions_list" | head -n 1)
+    if [[ $ret_code -ne 0 ]] ; then
+        echo "Can not detect nvidia driver version."
+        echo "CMD: \"$cmd\""
+        echo "Result: \"$driver_versions_list\""
+        echo "nvidia-smi retcode: $ret_code"
         exit 1
     fi
 

--- a/patch.sh
+++ b/patch.sh
@@ -192,6 +192,7 @@ patch_common () {
         echo "CMD: \"$cmd\""
         echo "Result: \"$driver_versions_list\""
         echo "nvidia-smi retcode: $ret_code"
+        exit 1
     fi
 
     echo "Detected nvidia driver version: $driver_version"

--- a/patch.sh
+++ b/patch.sh
@@ -187,7 +187,7 @@ patch_common () {
     driver_versions_list=$($cmd)
     ret_code=$?
     driver_version=$(echo "$driver_versions_list" | head -n 1)
-    if [ $ret_code -ne 0 ] && [ -nz driver_version ] ; then
+    if [[ $ret_code -ne 0 ]] ; then
         echo "Can not detect nvidia driver version."
         echo "CMD: \"$cmd\""
         echo "Result: \"$driver_versions_list\""

--- a/patch.sh
+++ b/patch.sh
@@ -183,9 +183,15 @@ patch_common () {
         exit 1
     fi
 
-    if ! driver_version=$("$NVIDIA_SMI" --query-gpu=driver_version --format=csv,noheader,nounits | head -n 1) ; then
-        echo 'Something went wrong. Check nvidia driver'
-        exit 1
+    cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
+    driver_versions_list=$($cmd)
+    ret_code=$?
+    driver_version=$(echo "$driver_versions_list" | head -n 1)
+    if [ $ret_code -ne 0 ] && [ -nz driver_version ] ; then
+        echo "Can not detect nvidia driver version."
+        echo "CMD: \"$cmd\""
+        echo "Result: \"$driver_versions_list\""
+        echo "nvidia-smi retcode: $ret_code"
     fi
 
     echo "Detected nvidia driver version: $driver_version"


### PR DESCRIPTION
**Purpose of proposed changes**

Sometimes patching nvidia drivers fails inside docker container with no reason. This PR will add more descriptive info on what actually happens on failure.

**Essential steps taken**

In order to adding more debug info this solution fixed issue #267. I think that problem was in checking return value of `nvidia-smi` command: sometimes it fails despite that variable contains correct driver version.
