### PR TITLE
ndl: workaround broken layout on Vulkan Beta downloads page

### DIFF
--- a/tools/nv-driver-locator/get_vulkan_downloads.py
+++ b/tools/nv-driver-locator/get_vulkan_downloads.py
@@ -55,10 +55,10 @@ def get_drivers(*, timeout=10):
     body = fetch_url(URL)
     soup = BeautifulSoup(body, 'html.parser')
     result = []
-    for sibling in soup.find('h4',
-                             string=re.compile(r'Vulkan .* Developer Beta Driver Downloads', re.I)
-                             ).next_siblings:
-        if sibling.name == 'h4':
+    section_start = soup.find('h4', string=re.compile(r'Vulkan Beta Driver Downloads', re.I))
+    section_end = section_start.find_next("h4")
+    for sibling in section_start.find_all_next():
+        if sibling is section_end:
             break
         if sibling.name == 'p' and sibling.b is not None:
             m = re.match(r'(Windows|Linux)\s+((\d+\.){1,2}\d+)', sibling.b.string)


### PR DESCRIPTION
**Purpose of proposed changes**

Fix #297 

**Essential steps taken**

Vulkan Beta downloads page contains odd `</p>` tag shortly after header which we consider as a start of section with driver downloads, so it breaks `next_siblings` iteration in `bs4`. Switched to `find_all_next()` iterator with condition to stop on next `<h4>` tag.