### PR TITLE
linux: add -d switch to specify nvidia driver version manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
 # bash ./patch.sh -h
 
 SYNOPSIS
-       patch.sh [-s] [-r|-h|-c VERSION|-l]
+       patch-fbc.sh [-s] [-r|-h|-c VERSION|-l]
 
 DESCRIPTION
-       The patch for Nvidia drivers to remove NVENC session limit
+       The patch for Nvidia drivers to allow FBC on consumer devices
 
        -s             Silent mode (No output)
        -r             Rollback to original (Restore lib from backup)
@@ -139,6 +139,8 @@ DESCRIPTION
        -c VERSION     Check if version VERSION supported by this patch.
                       Returns true exit code (0) if version is supported.
        -l             List supported driver versions
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
 
 ```
 

--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -6,6 +6,7 @@ set -euo pipefail ; # <- this semicolon and comment make options apply
 
 backup_path="/opt/nvidia/libnvidia-fbc-backup"
 silent_flag=''
+manual_driver_version=''
 
 print_usage() { printf '
 SYNOPSIS
@@ -20,6 +21,8 @@ DESCRIPTION
        -c VERSION     Check if version VERSION supported by this patch.
                       Returns true exit code (0) if version is supported.
        -l             List supported driver versions
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
 
 '
 }
@@ -27,13 +30,14 @@ DESCRIPTION
 # shellcheck disable=SC2209
 opmode="patch"
 
-while getopts 'rshc:l' flag; do
+while getopts 'rshc:ld:' flag; do
     case "${flag}" in
         r) opmode="${opmode}rollback" ;;
         s) silent_flag='true' ;;
         h) opmode="${opmode}help" ;;
         c) opmode="${opmode}checkversion" ; checked_version="$OPTARG" ;;
         l) opmode="${opmode}listversions" ;;
+        d) manual_driver_version="$OPTARG" ;;
         *) echo "Incorrect option specified in command line" ; exit 2 ;;
     esac
 done
@@ -157,19 +161,25 @@ patch_common () {
         exit 1
     fi
 
-    cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
-    driver_versions_list=$($cmd)
-    ret_code=$?
-    driver_version=$(echo "$driver_versions_list" | head -n 1)
-    if [[ $ret_code -ne 0 ]] ; then
-        echo "Can not detect nvidia driver version."
-        echo "CMD: \"$cmd\""
-        echo "Result: \"$driver_versions_list\""
-        echo "nvidia-smi retcode: $ret_code"
-        exit 1
-    fi
+    if [[ "$manual_driver_version" ]]; then
+        driver_version="$manual_driver_version"
 
-    echo "Detected nvidia driver version: $driver_version"
+        echo "Using manually entered nvidia driver version: $driver_version"
+    else
+        cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
+        driver_versions_list=$($cmd)
+        ret_code=$?
+        driver_version=$(echo "$driver_versions_list" | head -n 1)
+        if [[ $ret_code -ne 0 ]] ; then
+            echo "Can not detect nvidia driver version."
+            echo "CMD: \"$cmd\""
+            echo "Result: \"$driver_versions_list\""
+            echo "nvidia-smi retcode: $ret_code"
+            exit 1
+        fi
+
+        echo "Detected nvidia driver version: $driver_version"
+    fi
 
     if ! check_version_supported "$driver_version" ; then
         echo "Patch for this ($driver_version) nvidia driver not found."

--- a/patch.sh
+++ b/patch.sh
@@ -6,6 +6,7 @@ set -euo pipefail ; # <- this semicolon and comment make options apply
 
 backup_path="/opt/nvidia/libnvidia-encode-backup"
 silent_flag=''
+manual_driver_version=''
 
 print_usage() { printf '
 SYNOPSIS
@@ -20,20 +21,22 @@ DESCRIPTION
        -c VERSION     Check if version VERSION supported by this patch.
                       Returns true exit code (0) if version is supported.
        -l             List supported driver versions
-
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
 '
 }
 
 # shellcheck disable=SC2209
 opmode="patch"
 
-while getopts 'rshc:l' flag; do
+while getopts 'rshc:ld:' flag; do
     case "${flag}" in
         r) opmode="${opmode}rollback" ;;
         s) silent_flag='true' ;;
         h) opmode="${opmode}help" ;;
         c) opmode="${opmode}checkversion" ; checked_version="$OPTARG" ;;
         l) opmode="${opmode}listversions" ;;
+        d) manual_driver_version="$OPTARG" ;;
         *) echo "Incorrect option specified in command line" ; exit 2 ;;
     esac
 done
@@ -231,19 +234,25 @@ patch_common () {
         exit 1
     fi
 
-    cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
-    driver_versions_list=$($cmd)
-    ret_code=$?
-    driver_version=$(echo "$driver_versions_list" | head -n 1)
-    if [[ $ret_code -ne 0 ]] ; then
-        echo "Can not detect nvidia driver version."
-        echo "CMD: \"$cmd\""
-        echo "Result: \"$driver_versions_list\""
-        echo "nvidia-smi retcode: $ret_code"
-        exit 1
-    fi
+    if [[ "$manual_driver_version" ]]; then
+        driver_version="$manual_driver_version"
 
-    echo "Detected nvidia driver version: $driver_version"
+        echo "Using manually entered nvidia driver version: $driver_version"
+    else
+        cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
+        driver_versions_list=$($cmd)
+        ret_code=$?
+        driver_version=$(echo "$driver_versions_list" | head -n 1)
+        if [[ $ret_code -ne 0 ]] ; then
+            echo "Can not detect nvidia driver version."
+            echo "CMD: \"$cmd\""
+            echo "Result: \"$driver_versions_list\""
+            echo "nvidia-smi retcode: $ret_code"
+            exit 1
+        fi
+
+        echo "Detected nvidia driver version: $driver_version"
+    fi
 
     if ! check_version_supported "$driver_version" ; then
         echo "Patch for this ($driver_version) nvidia driver not found."


### PR DESCRIPTION
**Purpose of proposed changes**

Make it possible to specify driver version to patch without running `nvidia-smi`.
We use nvidia-patch during automated installation process and `nvidia-smi` is not available because the actual GPU is not connected to the computer yet. This new option allows us to patch the driver even with GPU not connected.

**Essential steps taken**

I added `-d VERSION` switch to both `patch.sh` and `patch-fbc.sh` to make it possible to specify driver version to patch manually. It is used in `patch_common` instead of running `nvidia-smi`.
