### PR TITLE
linux: add NvFBC for driver versions 460.27.04 and 460.32.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
 | 455.45.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.45.01/NVIDIA-Linux-x86_64-455.45.01.run) |
 | 455.46.01 | YES | YES |  |
 | 455.46.02 | YES | YES |  |
-| 460.27.04 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run) |
-| 460.32.03 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run) |
+| 460.27.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run) |
+| 460.32.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run) |
 
 ## Synopsis
 

--- a/drivers.json
+++ b/drivers.json
@@ -486,16 +486,16 @@
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.102.04/NVIDIA-Linux-x86_64-450.102.04.run"
                 },
                 {
-                    "version": "460.32.03",
-                    "nvenc_patch": true,
-                    "nvfbc_patch": false,
-                    "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run"
-                },
-                {
                     "version": "460.27.04",
                     "nvenc_patch": true,
-                    "nvfbc_patch": false,
+                    "nvfbc_patch": true,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run"
+                },
+                {
+                    "version": "460.32.03",
+                    "nvenc_patch": true,
+                    "nvfbc_patch": true,
+                    "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run"
                 }
             ],
             "example": {

--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -95,6 +95,8 @@ declare -A patch_list=(
     ["455.45.01"]='s/\x83\xf8\x01\x0f\x84\x85/\x83\xf8\x69\x0f\x84\x85/'
     ["455.46.01"]='s/\x83\xf8\x01\x0f\x84\x85/\x83\xf8\x69\x0f\x84\x85/'
     ["455.46.02"]='s/\x83\xf8\x01\x0f\x84\x83/\x83\xf8\x69\x0f\x84\x83/'
+    ["460.27.04"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
+    ["460.32.03"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
 )
 
 declare -A object_list=(
@@ -146,6 +148,8 @@ declare -A object_list=(
     ["455.45.01"]='libnvidia-fbc.so'
     ["455.46.01"]='libnvidia-fbc.so'
     ["455.46.02"]='libnvidia-fbc.so'
+    ["460.27.04"]='libnvidia-fbc.so'
+    ["460.32.03"]='libnvidia-fbc.so'
 )
 
 check_version_supported () {


### PR DESCRIPTION
**Purpose of proposed changes**

Enable NvFBC on driver versions 460.27.04 and 460.32.03
Fixes #365 

**Essential steps taken**

Educated guess, referencing x86-Assembly documentation

Tested with OBS NvFBC plugin against both driver versions on a GTX 1070