### PR TITLE
Add NvFBC patch for 460.39 and 455.50.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NVENC and NvFBC patches for Nvidia drivers
 ==========================================
 
-![GitHub last commit](https://img.shields.io/github/last-commit/keylase/nvidia-patch.svg) ![Latest version](https://img.shields.io/badge/latest%20linux%20driver%20version-460.32.03-brightgreen.svg)
+![GitHub last commit](https://img.shields.io/github/last-commit/keylase/nvidia-patch.svg) ![Latest version](https://img.shields.io/badge/latest%20linux%20driver%20version-460.39-brightgreen.svg)
 
 [NVENC patch](patch.sh) removes restriction on maximum number of simultaneous NVENC video encoding sessions imposed by Nvidia to consumer-grade GPUs.
 
@@ -127,8 +127,10 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
 | 455.46.02 | YES | YES |  |
 | 455.46.04 | YES | YES |  |
 | 455.50.02 | YES | YES |  |
+| 455.50.03 | NO | YES |  |
 | 460.27.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run) |
 | 460.32.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run) |
+| 460.39 | NO | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.39/NVIDIA-Linux-x86_64-460.39.run) |
 
 ## Synopsis
 

--- a/drivers.json
+++ b/drivers.json
@@ -503,9 +503,20 @@
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run"
                 },
                 {
+                	"version": "460.39",
+                	"nvenc_patch": false,
+                	"nvfbc_patch": true,
+                	"driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.39/NVIDIA-Linux-x86_64-460.39.run"
+                },
+                {
                     "version": "455.50.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true
+                },
+                {
+                	"version": "455.50.03",
+                	"nvenc_patch": false,
+                	"nvfbc_patch": true
                 }
             ],
             "example": {

--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -97,8 +97,10 @@ declare -A patch_list=(
     ["455.46.02"]='s/\x83\xf8\x01\x0f\x84\x83/\x83\xf8\x69\x0f\x84\x83/'
     ["455.46.04"]='s/\x83\xf8\x01\x0f\x84\x85/\x83\xf8\x69\x0f\x84\x85/'
     ["455.50.02"]='s/\x83\xf8\x01\x0f\x84\x85/\x83\xf8\x69\x0f\x84\x85/'
+    ["455.50.03"]='s/\x83\xf8\x01\x0f\x84\x85/\x83\xf8\x69\x0f\x84\x85/'
     ["460.27.04"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
     ["460.32.03"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
+    ["460.39"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
 )
 
 declare -A object_list=(
@@ -152,8 +154,10 @@ declare -A object_list=(
     ["455.46.02"]='libnvidia-fbc.so'
     ["455.46.04"]='libnvidia-fbc.so'
     ["455.50.02"]='libnvidia-fbc.so'
+    ["455.50.03"]='libnvidia-fbc.so'
     ["460.27.04"]='libnvidia-fbc.so'
     ["460.32.03"]='libnvidia-fbc.so'
+    ["460.39"]='libnvidia-fbc.so'
 )
 
 check_version_supported () {


### PR DESCRIPTION
**Purpose of proposed changes**

Add NvFBC patches for 460.39 and Vulkan Beta 455.50.03

**Essential steps taken**

sha256sum for 455.50.02 > 455.50.03 and 460.32.03 > 460.39 respectively are identical, so patches will be unchanged.
