### PR TITLE
Add NvFBC patch for 470.42.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NVENC and NvFBC patches for Nvidia drivers
 ==========================================
 
-![GitHub last commit](https://img.shields.io/github/last-commit/keylase/nvidia-patch.svg) ![Latest version](https://img.shields.io/badge/latest%20linux%20driver%20version-465.31-brightgreen.svg)
+![GitHub last commit](https://img.shields.io/github/last-commit/keylase/nvidia-patch.svg) ![Latest version](https://img.shields.io/badge/latest%20linux%20driver%20version-470.42.01-brightgreen.svg)
 
 [NVENC patch](patch.sh) removes restriction on maximum number of simultaneous NVENC video encoding sessions imposed by Nvidia to consumer-grade GPUs.
 
@@ -144,6 +144,7 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
 | 465.24.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.24.02/NVIDIA-Linux-x86_64-465.24.02.run) |
 | 465.27 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.27/NVIDIA-Linux-x86_64-465.27.run) |
 | 465.31 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.31/NVIDIA-Linux-x86_64-465.31.run) |
+| 470.42.01 | NO | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.42.01/NVIDIA-Linux-x86_64-470.42.01.run) |
 
 ## Synopsis
 

--- a/drivers.json
+++ b/drivers.json
@@ -591,6 +591,12 @@
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.84/NVIDIA-Linux-x86_64-460.84.run"
+                },
+                {
+                    "version": "470.42.01",
+                    "nvenc_patch": false,
+                    "nvfbc_patch": true,
+                    "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.42.01/NVIDIA-Linux-x86_64-470.42.01.run"
                 }
             ],
             "example": {

--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -114,6 +114,7 @@ declare -A patch_list=(
     ["465.24.02"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
     ["465.27"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
     ["465.31"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
+    ["470.42.01"]='s/\x83\xfe\x01\x73\x08\x48/\x83\xfe\x00\x72\x08\x48/'
 )
 
 declare -A object_list=(
@@ -184,6 +185,7 @@ declare -A object_list=(
     ["465.24.02"]='libnvidia-fbc.so'
     ["465.27"]='libnvidia-fbc.so'
     ["465.31"]='libnvidia-fbc.so'
+    ["470.42.01"]='libnvidia-fbc.so'
 )
 
 check_version_supported () {


### PR DESCRIPTION
**Purpose of proposed changes**

Adds NvFBC patch for 470.42.01

**Essential steps taken**

- Sha256sum did not match, verified area affected by patch was unaffected by these changes.
- Tested patch using OBS FBC plugin on GTX 1070
