### PR TITLE
Support patching Flatpak NVIDIA drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
 # bash ./patch.sh -h
 
 SYNOPSIS
-       patch.sh [-s] [-r|-h|-c VERSION|-l]
+       patch.sh [-s] [-r|-h|-c VERSION|-l|-f]
 
 DESCRIPTION
        The patch for Nvidia drivers to remove NVENC session limit
@@ -170,6 +170,7 @@ DESCRIPTION
        -l             List supported driver versions
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
+       -f             Enable support for Flatpak NVIDIA drivers.
 
 ```
 
@@ -177,7 +178,7 @@ DESCRIPTION
 # bash ./patch-fbc.sh -h
 
 SYNOPSIS
-       patch-fbc.sh [-s] [-r|-h|-c VERSION|-l]
+       patch-fbc.sh [-s] [-r|-h|-c VERSION|-l|-f]
 
 DESCRIPTION
        The patch for Nvidia drivers to allow FBC on consumer devices
@@ -190,7 +191,7 @@ DESCRIPTION
        -l             List supported driver versions
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
-
+       -f             Enable support for Flatpak NVIDIA drivers.
 
 ```
 
@@ -247,6 +248,22 @@ Essentially all you need to do during build is:
 * Make sure `docker-entrypoint.sh` is invoked on container start.
 
 `docker-entrypoint.sh` script does on-the-fly patching by means of manipulating dynamic linker to workaround read-only mount of Nvidia runtime. Finally it passes original docker command to shell, like if entrypoint was not restricted by `ENTRYPOINT` directive. So `docker run --runtime=nvidia -it mycontainer echo 123` will print `123`. Also it can be just invoked from your entrypoint script, if you have any.
+
+## Flatpak support
+
+If you use a Flatpak app that uses NVENC/NvFBC (e.g. OBS Studio, Kdenlive), it's recommended that you patch the NVIDIA drivers for Flatpak as well. To do so, just pass the `-f` parameter to either `patch.sh` or `patch-fbc.sh`, like so:
+
+```bash
+bash ./patch.sh -f
+bash ./patch-fbc.sh -f
+```
+
+In case something goes wrong, you can restore the original Flatpak drivers by adding the `-r` paramater:
+
+```
+bash ./patch.sh -f -r
+bash ./patch-fbc.sh -f -r
+```
 
 ## Benchmarks
 

--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -7,10 +7,12 @@ set -euo pipefail ; # <- this semicolon and comment make options apply
 backup_path="/opt/nvidia/libnvidia-fbc-backup"
 silent_flag=''
 manual_driver_version=''
+flatpak_flag=''
+backup_suffix=''
 
 print_usage() { printf '
 SYNOPSIS
-       patch-fbc.sh [-s] [-r|-h|-c VERSION|-l]
+       patch-fbc.sh [-s] [-r|-h|-c VERSION|-l|-f]
 
 DESCRIPTION
        The patch for Nvidia drivers to allow FBC on consumer devices
@@ -23,14 +25,14 @@ DESCRIPTION
        -l             List supported driver versions
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
-
+       -f             Enable support for Flatpak NVIDIA drivers.
 '
 }
 
 # shellcheck disable=SC2209
 opmode="patch"
 
-while getopts 'rshc:ld:' flag; do
+while getopts 'rshc:ld:f' flag; do
     case "${flag}" in
         r) opmode="${opmode}rollback" ;;
         s) silent_flag='true' ;;
@@ -38,12 +40,18 @@ while getopts 'rshc:ld:' flag; do
         c) opmode="${opmode}checkversion" ; checked_version="$OPTARG" ;;
         l) opmode="${opmode}listversions" ;;
         d) manual_driver_version="$OPTARG" ;;
+        f) flatpak_flag='true' ;;
         *) echo "Incorrect option specified in command line" ; exit 2 ;;
     esac
 done
 
 if [[ $silent_flag ]]; then
     exec 1> /dev/null
+fi
+
+if [[ $flatpak_flag ]]; then
+    backup_suffix='.flatpak'
+    echo "WARNING: Flatpak flag enabled (-f), modifying ONLY the Flatpak driver."
 fi
 
 declare -A patch_list=(
@@ -203,6 +211,14 @@ check_version_supported () {
     [[ "${patch_list[$ver]+isset}" && "${object_list[$ver]+isset}" ]]
 }
 
+get_flatpak_driver_path () {
+    # Flatpak's package versioning replaces '.' by '-'
+    version="$(echo "$1" | tr '.' '-')"
+    if path=$(flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-${version}" 2>/dev/null); then
+        echo "$path/files/lib"
+    fi
+}
+
 get_supported_versions () {
     for drv in "${!patch_list[@]}"; do
         [[ "${object_list[$drv]+isset}" ]] && echo "$drv"
@@ -246,6 +262,17 @@ patch_common () {
     patch="${patch_list[$driver_version]}"
     object="${object_list[$driver_version]}"
 
+    if [[ $flatpak_flag ]]; then
+        driver_dir=$(get_flatpak_driver_path "$driver_version")
+        if [ -z "$driver_dir" ]; then
+            echo "ERROR: Flatpak package for driver $driver_version does not appear to be installed."
+            echo "Try rebooting your computer and/or running 'flatpak update'."
+            exit 1
+        fi
+        # return early because the code below is out of scope for the Flatpak driver
+        return 0
+    fi
+
     declare -a driver_locations=(
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
@@ -267,10 +294,10 @@ patch_common () {
 
 rollback () {
     patch_common
-    if [[ -f "$backup_path/$object.$driver_version" ]]; then
-        cp -p "$backup_path/$object.$driver_version" \
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        cp -p "$backup_path/$object.$driver_version$backup_suffix" \
            "$driver_dir/$object.$driver_version"
-        echo "Restore from backup $object.$driver_version"
+        echo "Restore from backup $object.$driver_version$backup_suffix"
     else
         echo "Backup not found. Try to patch first."
         exit 1
@@ -279,8 +306,8 @@ rollback () {
 
 patch () {
     patch_common
-    if [[ -f "$backup_path/$object.$driver_version" ]]; then
-        bkp_hash="$(sha1sum "$backup_path/$object.$driver_version" | cut -f1 -d\ )"
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        bkp_hash="$(sha1sum "$backup_path/$object.$driver_version$backup_suffix" | cut -f1 -d\ )"
         drv_hash="$(sha1sum "$driver_dir/$object.$driver_version" | cut -f1 -d\ )"
         if [[ "$bkp_hash" != "$drv_hash" ]] ; then
             echo "Backup exists and driver file differ from backup. Skipping patch."
@@ -290,10 +317,10 @@ patch () {
         echo "Attention! Backup not found. Copying current $object to backup."
         mkdir -p "$backup_path"
         cp -p "$driver_dir/$object.$driver_version" \
-           "$backup_path/$object.$driver_version"
+           "$backup_path/$object.$driver_version$backup_suffix"
     fi
-    sha1sum "$backup_path/$object.$driver_version"
-    sed "$patch" "$backup_path/$object.$driver_version" > \
+    sha1sum "$backup_path/$object.$driver_version$backup_suffix"
+    sed "$patch" "$backup_path/$object.$driver_version$backup_suffix" > \
       "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
     sha1sum "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
     ldconfig

--- a/patch.sh
+++ b/patch.sh
@@ -7,10 +7,12 @@ set -euo pipefail ; # <- this semicolon and comment make options apply
 backup_path="/opt/nvidia/libnvidia-encode-backup"
 silent_flag=''
 manual_driver_version=''
+flatpak_flag=''
+backup_suffix=''
 
 print_usage() { printf '
 SYNOPSIS
-       patch.sh [-s] [-r|-h|-c VERSION|-l]
+       patch.sh [-s] [-r|-h|-c VERSION|-l|-f]
 
 DESCRIPTION
        The patch for Nvidia drivers to remove NVENC session limit
@@ -23,13 +25,14 @@ DESCRIPTION
        -l             List supported driver versions
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
+       -f             Enable support for Flatpak NVIDIA drivers.
 '
 }
 
 # shellcheck disable=SC2209
 opmode="patch"
 
-while getopts 'rshc:ld:' flag; do
+while getopts 'rshc:ld:f' flag; do
     case "${flag}" in
         r) opmode="${opmode}rollback" ;;
         s) silent_flag='true' ;;
@@ -37,12 +40,18 @@ while getopts 'rshc:ld:' flag; do
         c) opmode="${opmode}checkversion" ; checked_version="$OPTARG" ;;
         l) opmode="${opmode}listversions" ;;
         d) manual_driver_version="$OPTARG" ;;
+        f) flatpak_flag='true' ;;
         *) echo "Incorrect option specified in command line" ; exit 2 ;;
     esac
 done
 
 if [[ $silent_flag ]]; then
     exec 1> /dev/null
+fi
+
+if [[ $flatpak_flag ]]; then
+    backup_suffix='.flatpak'
+    echo "WARNING: Flatpak flag enabled (-f), modifying ONLY the Flatpak driver."
 fi
 
 declare -A patch_list=(
@@ -276,6 +285,14 @@ check_version_supported () {
     [[ "${patch_list[$ver]+isset}" && "${object_list[$ver]+isset}" ]]
 }
 
+get_flatpak_driver_path () {
+    # Flatpak's package versioning replaces '.' by '-'
+    version="$(echo "$1" | tr '.' '-')"
+    if path=$(flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-${version}" 2>/dev/null); then
+        echo "$path/files/lib"
+    fi
+}
+
 get_supported_versions () {
     for drv in "${!patch_list[@]}"; do
         [[ "${object_list[$drv]+isset}" ]] && echo "$drv"
@@ -319,6 +336,17 @@ patch_common () {
     patch="${patch_list[$driver_version]}"
     object="${object_list[$driver_version]}"
 
+    if [[ $flatpak_flag ]]; then
+        driver_dir=$(get_flatpak_driver_path "$driver_version")
+        if [ -z "$driver_dir" ]; then
+            echo "ERROR: Flatpak package for driver $driver_version does not appear to be installed."
+            echo "Try rebooting your computer and/or running 'flatpak update'."
+            exit 1
+        fi
+        # return early because the code below is out of scope for the Flatpak driver
+        return 0
+    fi
+
     declare -a driver_locations=(
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
@@ -340,10 +368,10 @@ patch_common () {
 
 rollback () {
     patch_common
-    if [[ -f "$backup_path/$object.$driver_version" ]]; then
-        cp -p "$backup_path/$object.$driver_version" \
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        cp -p "$backup_path/$object.$driver_version$backup_suffix" \
            "$driver_dir/$object.$driver_version"
-        echo "Restore from backup $object.$driver_version"
+        echo "Restore from backup $object.$driver_version$backup_suffix"
     else
         echo "Backup not found. Try to patch first."
         exit 1
@@ -352,8 +380,8 @@ rollback () {
 
 patch () {
     patch_common
-    if [[ -f "$backup_path/$object.$driver_version" ]]; then
-        bkp_hash="$(sha1sum "$backup_path/$object.$driver_version" | cut -f1 -d\ )"
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        bkp_hash="$(sha1sum "$backup_path/$object.$driver_version$backup_suffix" | cut -f1 -d\ )"
         drv_hash="$(sha1sum "$driver_dir/$object.$driver_version" | cut -f1 -d\ )"
         if [[ "$bkp_hash" != "$drv_hash" ]] ; then
             echo "Backup exists and driver file differ from backup. Skipping patch."
@@ -363,10 +391,10 @@ patch () {
         echo "Attention! Backup not found. Copying current $object to backup."
         mkdir -p "$backup_path"
         cp -p "$driver_dir/$object.$driver_version" \
-           "$backup_path/$object.$driver_version"
+           "$backup_path/$object.$driver_version$backup_suffix"
     fi
-    sha1sum "$backup_path/$object.$driver_version"
-    sed "$patch" "$backup_path/$object.$driver_version" > \
+    sha1sum "$backup_path/$object.$driver_version$backup_suffix"
+    sed "$patch" "$backup_path/$object.$driver_version$backup_suffix" > \
       "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
     sha1sum "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
     ldconfig


### PR DESCRIPTION
**Purpose of proposed changes**

This PR allows patching the [Flatpak NVIDIA drivers](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia), which is useful for Flatpak apps using NVENC/NvFBC (mainly useful for [OBS Studio](https://flathub.org/apps/details/com.obsproject.Studio) with [this plugin](https://gitlab.com/fzwoch/obs-nvfbc) I'm preparing to package; and also [Kdenlive](https://flathub.org/apps/details/org.kde.kdenlive)).

**Essential steps taken**

* I've added the `-f` flag to both scripts , which when used, enables patching Flatpak drivers. Backup and restore should also work flawlessly for the Flatpak version.
* Automatic backup with `-f` adds a `.flatpak` suffix to the filenames, in order to differentiate them from backup files from the host drivers.
