### PR TITLE
add installer downloader by version or url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# https://github.com/github/gitignore/blob/main/Python.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+

--- a/win/tools/autopatch/.gitignore
+++ b/win/tools/autopatch/.gitignore
@@ -105,3 +105,11 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+# APP
+# dont commit 7zip files 7z.dll 7z.exe
+7z.*
+
+temp
+!.gitempty

--- a/win/tools/autopatch/.gitignore
+++ b/win/tools/autopatch/.gitignore
@@ -111,5 +111,5 @@ venv.bak/
 # dont commit 7zip files 7z.dll 7z.exe
 7z.*
 
-temp
+temp/*
 !.gitempty

--- a/win/tools/autopatch/README.md
+++ b/win/tools/autopatch/README.md
@@ -13,6 +13,14 @@ Note: when command line options with multiple possible arguments supplied (like 
 
 * Python 3.2+
 * 7zip CLI utility
+  * 7z.exe and 7z.dll are required, next to autopatch.py or set path with parameter
+
+## Examples
+```
+python.exe autopatch.py temp/512.95-desktop-win10-win11-64bit-international-dch-whql.exe
+python.exe autopatch.py https://international.download.nvidia.com/Windows/512.95/512.95-desktop-win10-win11-64bit-international-dch-whql.exe
+python.exe autopatch.py 512.95
+```
 
 ## Synopsys
 

--- a/win/tools/autopatch/autopatch.py
+++ b/win/tools/autopatch/autopatch.py
@@ -9,6 +9,7 @@ from binascii import unhexlify
 import xml.etree.ElementTree as ET
 import itertools
 import functools
+import urllib.request
 
 
 CRLF = b"\x0d\x0a"
@@ -193,6 +194,21 @@ def patch_flow(installer_file, search, replacement, target, target_name, patch_n
     replacement = unhexlify(replacement)
     assert len(search) == len(replacement), "len() of search and replacement"\
         " is not equal"
+
+    # check if installer file exists or try to download
+    if not os.path.isfile(installer_file):  #installer file does not exists, get url for download
+        if not installer_file.startswith("http"):  #installer_file is a version, parse to url
+            filename = installer_file+"-desktop-win10-win11-64bit-international-dch-whql.exe"
+            installer_file = "https://international.download.nvidia.com/Windows/"+installer_file+"/"+filename
+        else:  # installer_file is an url
+            filename = os.path.basename(installer_file)
+        # download installer and save in .temp
+        print(f"Downloading... ( {installer_file} TO {os.path.join('temp', filename)} )")
+        print("This may take a while (~800MB)")
+        urllib.request.urlretrieve(installer_file, os.path.join('temp', filename))
+        installer_file = os.path.join('temp', filename)
+
+
     patch = make_patch(installer_file,
                        arch_tgt=target,
                        search=search,


### PR DESCRIPTION
**Purpose of proposed changes**

Automatically download the driver file for windows tool auto patcher, saves some time downloading and moving it by hand

Support just the version number or the url to download the file.   
Version number only supports the win10-11 dch driver (as its hardcoded).   

Also add a global basic python `.gitignore`

```
python.exe autopatch.py temp/512.95-desktop-win10-win11-64bit-international-dch-whql.exe
python.exe autopatch.py https://international.download.nvidia.com/Windows/512.95/512.95-desktop-win10-win11-64bit-international-dch-whql.exe
python.exe autopatch.py 512.95
```