### PR TITLE
support dch driver variant

### DIFF
--- a/tools/readme-autogen/README.md
+++ b/tools/readme-autogen/README.md
@@ -28,7 +28,7 @@ Just run script. It will update files in your repo working copy.
 
 ## Examples
 
-Here is real commands used for Windows driver 441.28 series:
+Here is real commands used for Windows driver 441.28 and 512.95 series:
 
 ```bash
 ./add_driver.py -W --variant "Studio Driver" 441.28
@@ -36,7 +36,10 @@ Here is real commands used for Windows driver 441.28 series:
 ./add_driver.py -W -P Quadro -w win7 441.28
 ./add_driver.py -W -P Quadro -w ws2012 441.28
 ./add_driver.py -W -P Quadro -w ws2016 441.28
+./add_driver.py -W -P GeForce --variant "DCH" -w win10 512.95
 ```
+
+> Variant DCH: Microsoft DCH (Declarative Componentized Hardware supported apps) drivers refers to a new universal Windows 10 driver package. [NVIDIA FAQ](https://nvidia.custhelp.com/app/answers/detail/a_id/4777/~/nvidia-dch%2Fstandard-display-drivers-for-windows-10-faq)
 
 ## Synopsis
 

--- a/tools/readme-autogen/constants.py
+++ b/tools/readme-autogen/constants.py
@@ -39,6 +39,7 @@ ENCODING='utf-8'
 DRIVER_URL_TEMPLATE = {
     (OSKind.Linux, None, None, None):                                       "https://international.download.nvidia.com/XFree86/Linux-x86_64/$version/NVIDIA-Linux-x86_64-$version.run",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, ''):                 "https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-whql.exe",
+    (OSKind.Windows, Product.GeForce, WinSeries.win10, 'DCH'):              "https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-dch-whql.exe",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, 'Studio Driver'):    "https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-nsd-whql.exe",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, 'Vulkan Beta'):      "",
     (OSKind.Windows, Product.Quadro, WinSeries.win10, ''):                  "https://international.download.nvidia.com/Windows/Quadro_Certified/$version/$version-quadro-rtx-desktop-notebook-win10-win11-64bit-international-whql.exe",
@@ -51,6 +52,7 @@ DRIVER_URL_TEMPLATE = {
 
 DRIVER_DIR_PREFIX = {
     (Product.GeForce, ''): '',
+    (Product.GeForce, 'DCH'): '',
     (Product.GeForce, 'Studio Driver'): 'nsd_',
     (Product.GeForce, 'Vulkan Beta'): '',
     (Product.Quadro, ''): 'quadro_',


### PR DESCRIPTION
**Purpose of proposed changes**

just adds the new nv*/micro* driver variant which is used as a few versions already.   
i migrated the older drivers in the next pr.

dch drivers have a diffrent url and the add_driver.py did not support it (404 without dch). I guess u set the url manual in the past.