### PR TITLE
Changed Windows README to show Windows 11 is now supported

### DIFF
--- a/win/README.md
+++ b/win/README.md
@@ -30,6 +30,7 @@ git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nv
   - Windows 8
   - Windows 8.1
   - Windows 10
+  - Windows 11
   - Windows Server 2008 R2
   - Windows Server 2012
   - Windows Server 2012 R2
@@ -63,7 +64,7 @@ Credits to [TroubleChute channel](https://www.youtube.com/channel/UCkih2oVTbXPEp
 
 ## Version Table
 
-### Windows 10 drivers
+### Windows 10, Windows 11 drivers
 
 
 | Product series | Version | x64 library patch | x86 library patch | Driver link |


### PR DESCRIPTION
**Purpose of proposed changes**

This change resolves keylase/nvidia-patch#453 which identified that Windows 11 is supported, and was meant to be updated in the README files, but this was never completed. This is now done.

**Essential steps taken**

Simply changed README file to remove confusion on whether or not Windows 11 is supported or not