### PR TITLE
patch(-fbc).sh: Add /usr/lib to search path

### DIFF
--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -325,6 +325,7 @@ patch_common () {
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
         '/usr/lib64'
+        '/usr/lib'
         "/usr/lib/nvidia-${driver_version%%.*}"
     )
 

--- a/patch.sh
+++ b/patch.sh
@@ -401,6 +401,7 @@ patch_common () {
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
         '/usr/lib64'
+        '/usr/lib'
         "/usr/lib/nvidia-${driver_version%%.*}"
     )
 


### PR DESCRIPTION
**Purpose of proposed changes**

Fix #560 

**Essential steps taken**

Untested, checking debian/ubuntu package file lists I do not see any change in the driver install paths. But some users report that their libs end up in `/usr/lib` so adding that in the search path.
