### PR TITLE
readme: remove ipfs mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@ If you want to donate, please send it to your favorite open source organizations
 
 ---
 
-## Mirrors
-
-IPFS site mirror: [https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/](https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/)
-
-IPFS git mirror:
-
-```
-git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nvidia-patch
-```
-
 ## Requirements
 - x86\_64 system architecture
 - GNU/Linux operating system

--- a/tools/readme-autogen/templates/linux_readme_master.tmpl
+++ b/tools/readme-autogen/templates/linux_readme_master.tmpl
@@ -17,16 +17,6 @@ If you want to donate, please send it to your favorite open source organizations
 
 ---
 
-## Mirrors
-
-IPFS site mirror: [https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/](https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/)
-
-IPFS git mirror:
-
-```
-git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nvidia-patch
-```
-
 ## Requirements
 - x86\_64 system architecture
 - GNU/Linux operating system

--- a/tools/readme-autogen/templates/windows_readme_master.tmpl
+++ b/tools/readme-autogen/templates/windows_readme_master.tmpl
@@ -13,16 +13,6 @@ If you like this project, best way to contribute is by sending PRs and fixing do
 
 ---
 
-## Mirrors
-
-IPFS site mirror: [https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/win/](https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/win/)
-
-IPFS git mirror:
-
-```
-git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nvidia-patch
-```
-
 ## Requirements
 
 - Any of following 64bit operating systems:

--- a/win/README.md
+++ b/win/README.md
@@ -13,16 +13,6 @@ If you like this project, best way to contribute is by sending PRs and fixing do
 
 ---
 
-## Mirrors
-
-IPFS site mirror: [https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/win/](https://ipfs.io/ipns/QmYTEwv2GjQhtdN9bDfpLfQrVD7YLb1Sbh8igX8cEe9hHF/win/)
-
-IPFS git mirror:
-
-```
-git clone https://ipfs.io/ipns/Qmed4r8yrBP162WK1ybd1DJWhLUi4t6mGuBoB9fLtjxR7u nvidia-patch
-```
-
 ## Requirements
 
 - Any of following 64bit operating systems:


### PR DESCRIPTION
**Purpose of proposed changes**

The IPFS mirror for the source code is not up anymore, so remove it for now.

Closes #582 
