### PR TITLE
linux: ensure bytes are valid before patching

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -457,6 +457,20 @@ patch_common () {
 
 }
 
+ensure_bytes_are_valid () {
+    driver_file="$driver_dir/$object.$driver_version"
+    original_bytes=$(awk -F / '$2 { print $2 }' <<< "$patch")
+    patched_bytes=$(awk -F / '$3 { print $3 }' <<< "$patch")
+    if LC_ALL=C grep -qaP "$original_bytes" "$driver_file"; then
+        return 0 # file is ready to be patched
+    fi
+    if LC_ALL=C grep -qaP "$patched_bytes" "$driver_file"; then
+        return 0 # file is likely patched already
+    fi
+    echo "Error: Could not find bytes '$original_bytes' to patch in '$driver_file'."
+    exit 1
+}
+
 rollback () {
     patch_common
     if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
@@ -471,6 +485,7 @@ rollback () {
 
 patch () {
     patch_common
+    ensure_bytes_are_valid
     if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
         bkp_hash="$(sha1sum "$backup_path/$object.$driver_version$backup_suffix" | cut -f1 -d\ )"
         drv_hash="$(sha1sum "$driver_dir/$object.$driver_version" | cut -f1 -d\ )"


### PR DESCRIPTION
**Purpose of proposed changes**

We use `sed` to replace original bytes by patched ones, but unfortunately `sed` doesn't report any errors when this substitution fails.

Now, before actually running `sed`, we check if these bytes that are soon to be replaced, actually exist in the driver file.

This will hopefully help people from submitting [wrong bytes](https://github.com/keylase/nvidia-patch/pull/631)... :smiling_face_with_tear: 

**Essential steps taken**

I manually tested this on the newly released 470.199.02 drivers by setting invalid bytes in `patch-fbc.sh` (and `patch.sh`), and thankfully the script caught it:

![image](https://github.com/keylase/nvidia-patch/assets/626206/11a8d154-c503-464f-8762-263730cb49e8)

And afterward I tested with the correct bytes and it also worked.