### PR TITLE
patch(-fbc).sh: Add Debian's Tesla driver to search path

### DIFF
--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -368,6 +368,8 @@ patch_common () {
     declare -a driver_locations=(
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+        '/usr/lib/x86_64-linux-gnu/nvidia/tesla/'
+        "/usr/lib/x86_64-linux-gnu/nvidia/tesla-${driver_version%%.*}/"
         '/usr/lib64'
         '/usr/lib'
         "/usr/lib/nvidia-${driver_version%%.*}"

--- a/patch.sh
+++ b/patch.sh
@@ -444,6 +444,8 @@ patch_common () {
     declare -a driver_locations=(
         '/usr/lib/x86_64-linux-gnu'
         '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+        '/usr/lib/x86_64-linux-gnu/nvidia/tesla/'
+        "/usr/lib/x86_64-linux-gnu/nvidia/tesla-${driver_version%%.*}/"
         '/usr/lib64'
         '/usr/lib'
         "/usr/lib/nvidia-${driver_version%%.*}"


### PR DESCRIPTION
Used by:
https://packages.debian.org/bookworm/amd64/libnvidia-encode1/filelist https://packages.debian.org/bookworm/amd64/libnvidia-tesla-encode1/filelist https://packages.debian.org/bookworm/amd64/libnvidia-tesla-470-encode1/filelist

**Purpose of proposed changes**

Support patching for Debian-packaged Nvidia driver (Tesla version)

**Essential steps taken**

N/A
