### PR TITLE
Fixed flatpak driver installed in user context not found

### DIFF
--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -312,7 +312,11 @@ check_version_supported () {
 get_flatpak_driver_path () {
     # Flatpak's package versioning replaces '.' by '-'
     version="$(echo "$1" | tr '.' '-')"
+    # Attempts to patch system flatpak
     if path=$(flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-${version}" 2>/dev/null); then
+        echo "$path/files/lib"
+    # If it isn't found will login as the user that envoked sudo & patch this version
+    elif path=$(su -c - ${SUDO_USER} 'flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-'${version}'"'); then
         echo "$path/files/lib"
     fi
 }

--- a/patch.sh
+++ b/patch.sh
@@ -388,7 +388,11 @@ check_version_supported () {
 get_flatpak_driver_path () {
     # Flatpak's package versioning replaces '.' by '-'
     version="$(echo "$1" | tr '.' '-')"
+    # Attempts to patch system flatpak
     if path=$(flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-${version}" 2>/dev/null); then
+        echo "$path/files/lib"
+    # If it isn't found will login as the user that envoked sudo & patch this version
+    elif path=$(su -c - ${SUDO_USER} 'flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-'${version}'"'); then
         echo "$path/files/lib"
     fi
 }


### PR DESCRIPTION
When running with sudo, the flatpak context of the user changes to root, this doesn't work if the driver was installed under the user's flatpak (The default method for many distros/applications).

This will first attempt to locate the driver path using the previous method (system flatpak). If it fails to find that, it will fall back to logging in as the user that invoked sudo & checking their flatpak context (user flatpak).

Since the copy preserves permissions & ownership, the user will still have access to the /opt/nvidia path where the backup is located, and the replaced driver also has the correct permissions as well. 

This method was tested and confirmed working with the `org.freedesktop.Platform.GL.nvidia-535-98` driver on Pop!_OS 22.04 LTS. But should be compatible with any OS with sudo support.