### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/gen_win_patches.yml
+++ b/.github/workflows/gen_win_patches.yml
@@ -23,6 +23,10 @@ on:
           - DCH
           - Studio Driver
           - DCH (Hotfix)
+      description:
+        description: 'Commit description'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -117,6 +121,6 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add -A
-          git diff --quiet --exit-code --cached || git commit -m "${{ env.OS }}: add support for ${{ env.VARIANT }} driver ${{ env.VERSION }}"
+          git diff --quiet --exit-code --cached || git commit -m "${{ env.OS }}: add support for ${{ env.VARIANT }} driver ${{ env.VERSION }}" -m "${{ inputs.description }}"
           git push origin master
           echo "Committed and pushed changes"

--- a/.github/workflows/gen_win_patches.yml
+++ b/.github/workflows/gen_win_patches.yml
@@ -1,9 +1,28 @@
 name: Generate Windows patches
 
 on:
-  release:
-    types:
-      - created
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'Operating System'
+        required: true
+        default: 'win'
+        type: choice
+        options:
+          - win
+          - linux
+      version:
+        description: 'Driver Version'
+        required: true
+        type: string
+      variant:
+        description: 'Driver Variant'
+        required: false
+        type: choice
+        options:
+          - DCH
+          - Studio Driver
+          - DCH (Hotfix)
 
 permissions:
   contents: write
@@ -14,35 +33,28 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Check release name and OS
-        id: check_release
+      - name: Check OS and variant
+        id: check_input
         run: |
-          release_name="${{ github.event.release.tag_name }}"
-          echo "Release Name: $release_name"
-          if [[ $release_name =~ (win)-(dch|studio)-([0-9]+\.[0-9]+(-[a-zA-Z]+)?)(-.+)? ]]; then
-            os="${BASH_REMATCH[1]}"
-            variant="${BASH_REMATCH[2]}"
-            version="${BASH_REMATCH[3]}"
-            echo "Operating System: $os"
-            echo "Variant: $variant"
-            echo "Version: $version"
+          os="${{ inputs.os }}"
+          variant="${{ inputs.variant }}"
+          version="${{ inputs.version }}"
+          echo "Operating System: $os"
+          echo "Variant: $variant"
+          echo "Version: $version"
 
+          if [[ $version =~ ([0-9]+\.[0-9]+(-[a-zA-Z]+)?)(-.+)? ]]; then
             if [ "$os" != "win" ]; then
               echo "Not a Windows release. Stopping the CI workflow."
               exit 0
             fi
 
-            if [ "$variant" == "dch" ]; then
-              variant="DCH"
-            elif [ "$variant" == "studio" ]; then
-              variant="Studio Driver"
-            fi
-
             echo "OS=$os" >> $GITHUB_ENV
             echo "VARIANT=$variant" >> $GITHUB_ENV
             echo "VERSION=$version" >> $GITHUB_ENV
+
           else
-            echo "Invalid release name format. Must be in the format 'win-dch-123.45' or 'win-studio-123.45'"
+            echo "Invalid driver version."
             exit 1
           fi
 
@@ -78,6 +90,8 @@ jobs:
             python autopatch.py ${{ env.VERSION }}
           elif [ "${{ env.VARIANT }}" == "Studio Driver" ]; then
             python autopatch.py https://international.download.nvidia.com/Windows/${{ env.VERSION }}/${{ env.VERSION }}-desktop-win10-win11-64bit-international-nsd-dch-whql.exe
+          elif [ "${{ env.VARIANT }}" == "DCH (Hotfix)" ]; then
+            python autopatch.py https://international.download.nvidia.com/Windows/${{ env.VERSION }}hf/${{ env.VERSION }}-desktop-notebook-win10-win11-64bit-international-dch.hf.exe
           fi
 
           echo "autopatch.py executed successfully"
@@ -106,13 +120,3 @@ jobs:
           git diff --quiet --exit-code --cached || git commit -m "${{ env.OS }}: add support for ${{ env.VARIANT }} driver ${{ env.VERSION }}"
           git push origin master
           echo "Committed and pushed changes"
-
-      - name: Upload Patch Files
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ${{ github.workspace }}/win/win10_x64/${{ env.VERSION }}/nvencodeapi64.1337
-            ${{ github.workspace }}/win/win10_x64/${{ env.VERSION }}/nvencodeapi.1337
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.event.release.tag_name }}

--- a/tools/readme-autogen/constants.py
+++ b/tools/readme-autogen/constants.py
@@ -42,6 +42,7 @@ DRIVER_URL_TEMPLATE = {
     (OSKind.Windows, Product.GeForce, WinSeries.win10, ''):                 "https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-whql.exe",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, 'DCH'):              ["https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-dch-whql.exe",
                                                                              "https://international.download.nvidia.com/tesla/$version/$version-data-center-tesla-desktop-win10-win11-64bit-dch-international.exe"],
+    (OSKind.Windows, Product.GeForce, WinSeries.win10, 'DCH (Hotfix)'):     "https://international.download.nvidia.com/Windows/${version}hf/$version-desktop-notebook-win10-win11-64bit-international-dch.hf.exe",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, 'Studio Driver'):    "https://international.download.nvidia.com/Windows/$version/$version-desktop-win10-win11-64bit-international-nsd-dch-whql.exe",
     (OSKind.Windows, Product.GeForce, WinSeries.win10, 'Vulkan Beta'):      "",
     (OSKind.Windows, Product.GeForce, WinSeries.ws2016, 'DCH'):             "https://international.download.nvidia.com/tesla/$version/$version-data-center-tesla-desktop-winserver-2016-2019-2022-dch-international.exe",
@@ -56,6 +57,7 @@ DRIVER_URL_TEMPLATE = {
 DRIVER_DIR_PREFIX = {
     (Product.GeForce, ''): '',
     (Product.GeForce, 'DCH'): '',
+    (Product.GeForce, 'DCH (Hotfix)'): '',
     (Product.GeForce, 'Studio Driver'): 'nsd_',
     (Product.GeForce, 'Vulkan Beta'): '',
     (Product.Quadro, ''): 'quadro_',

--- a/win/tools/autopatch/autopatch.py
+++ b/win/tools/autopatch/autopatch.py
@@ -90,6 +90,8 @@ class MultipleOccurencesException(Exception):
 class UnknownPlatformException(Exception):
     pass
 
+class InstallerNotFoundException(Exception):
+    pass
 
 class ExtractedTarget:
     name = None
@@ -229,14 +231,11 @@ def patch_flow(installer_file, search, replacement, target, target_name, patch_n
                     print(f"Using downloaded file in '{file_path}'")
                     installer_file = file_path
             except (urllib.error.URLError, Exception) as e:
-                print(f"Failed to download the file: {e}")
-                return
+                raise InstallerNotFoundException(f"Failed to download the file: {e}")
             except Exception as e:
-                print(f"An error occurred during download: {str(e)}")
-                return
+                raise InstallerNotFoundException(f"An error occurred during download: {str(e)}")
         else:
-            print(f"Invalid installer file or version: {installer_file}")
-            return
+            raise InstallerNotFoundException(f"Invalid installer file or version: {installer_file}")
 
     # Rest of the code remains the same...
     patch = make_patch(installer_file,


### PR DESCRIPTION
**Purpose of proposed changes**

Tagging release on an older commit (and then adding assets with new patch) is unnecessarily confusing.
Instead use Workflow dispatch for triggering new runs. This also allows us to take more complicated arguments and commit description (for fixes tags) etc.

Also support DCH (Hotfix) in the scripts.

**Essential steps taken**

Tested the workflow on my fork
