### PR TITLE
Add `patch-vk` for vulkan limit bypass support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ NVENC and NvFBC patches for Nvidia drivers
 
 [NvFBC patch](patch-fbc.sh) allows to use NvFBC on consumer-grade GPUs. It should be applied same way as NVENC `patch.sh`, except you have to use `patch-fbc.sh` instead.
 
+[Vulkan Patch](patch-vk.sh) removes restriction on maximum number of simultaneous Vulkan video encoding sessions imposed by Nvidia to consumer-grade GPUs, this is similar to [NVENC patch](patch.sh) but for Vulkan API.
+
 Main target operating system is **GNU/Linux**, but for **Windows** support see [**win** (clickable)](win).
 
 ---
@@ -25,205 +27,205 @@ If you want to donate, please send it to your favorite open source organizations
 
 ## Version Table
 
-| Version | NVENC patch | NVFBC patch | Driver link |
-| :---    |    :---:    |    :---:    |        ---: |
-| 375.39 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run) |
-| 390.77 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/390.77/NVIDIA-Linux-x86_64-390.77.run) |
-| 390.87 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/390.87/NVIDIA-Linux-x86_64-390.87.run) |
-| 390.147 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/390.147/NVIDIA-Linux-x86_64-390.147.run) |
-| 396.24 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/396.24/NVIDIA-Linux-x86_64-396.24.run) |
-| 396.26 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/396.26/NVIDIA-Linux-x86_64-396.26.run) |
-| 396.37 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run) |
-| 396.54 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/396.54/NVIDIA-Linux-x86_64-396.54.run) |
-| 410.48 | YES | NO |  |
-| 410.57 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.57/NVIDIA-Linux-x86_64-410.57.run) |
-| 410.73 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.73/NVIDIA-Linux-x86_64-410.73.run) |
-| 410.78 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run) |
-| 410.79 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/410.79/NVIDIA-Linux-x86_64-410.79.run) |
-| 410.93 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.93/NVIDIA-Linux-x86_64-410.93.run) |
-| 410.104 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/410.104/NVIDIA-Linux-x86_64-410.104.run) |
-| 415.18 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.18/NVIDIA-Linux-x86_64-415.18.run) |
-| 415.25 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.25/NVIDIA-Linux-x86_64-415.25.run) |
-| 415.27 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.27/NVIDIA-Linux-x86_64-415.27.run) |
-| 418.30 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.30/NVIDIA-Linux-x86_64-418.30.run) |
-| 418.43 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.43/NVIDIA-Linux-x86_64-418.43.run) |
-| 418.56 | YES | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run) |
-| 418.67 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run) |
-| 418.74 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.74/NVIDIA-Linux-x86_64-418.74.run) |
-| 418.87.00 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run) |
-| 418.87.01 | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.01.run) |
-| 418.88 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.88/NVIDIA-Linux-x86_64-418.88.run) |
-| 418.113 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.113/NVIDIA-Linux-x86_64-418.113.run) |
-| 430.09 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.09/NVIDIA-Linux-x86_64-430.09.run) |
-| 430.14 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.14/NVIDIA-Linux-x86_64-430.14.run) |
-| 430.26 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.26/NVIDIA-Linux-x86_64-430.26.run) |
-| 430.34 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.34/NVIDIA-Linux-x86_64-430.34.run) |
-| 430.40 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.40/NVIDIA-Linux-x86_64-430.40.run) |
-| 430.50 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.50/NVIDIA-Linux-x86_64-430.50.run) |
-| 430.64 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.64/NVIDIA-Linux-x86_64-430.64.run) |
-| 435.17 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/435.17/NVIDIA-Linux-x86_64-435.17.run) |
-| 435.21 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/435.21/NVIDIA-Linux-x86_64-435.21.run) |
-| 440.26 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.26/NVIDIA-Linux-x86_64-440.26.run) |
-| 440.31 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.31/NVIDIA-Linux-x86_64-440.31.run) |
-| 440.33.01 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run) |
-| 440.36 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.36/NVIDIA-Linux-x86_64-440.36.run) |
-| 440.43.01 | YES | YES |  |
-| 440.44 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.44/NVIDIA-Linux-x86_64-440.44.run) |
-| 440.48.02 | YES | YES |  |
-| 440.58.01 | YES | YES |  |
-| 440.58.02 | YES | YES |  |
-| 440.59 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.59/NVIDIA-Linux-x86_64-440.59.run) |
-| 440.64 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.64/NVIDIA-Linux-x86_64-440.64.run) |
-| 440.64.00 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/440.64.00/NVIDIA-Linux-x86_64-440.64.00.run) |
-| 440.66.02 | YES | YES |  |
-| 440.66.03 | YES | YES |  |
-| 440.66.04 | YES | YES |  |
-| 440.66.08 | YES | YES |  |
-| 440.66.09 | YES | YES |  |
-| 440.66.11 | YES | YES |  |
-| 440.66.12 | YES | YES |  |
-| 440.66.14 | YES | YES |  |
-| 440.66.15 | YES | YES |  |
-| 440.66.17 | YES | YES |  |
-| 440.82 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run) |
-| 440.95.01 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/440.95.01/NVIDIA-Linux-x86_64-440.95.01.run) |
-| 440.100 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.100/NVIDIA-Linux-x86_64-440.100.run) |
-| 440.118.02 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/440.118.02/NVIDIA-Linux-x86_64-440.118.02.run) |
-| 450.36.06 | YES | YES | [Driver link](https://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_450.36.06_linux.run) |
-| 450.51 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.51/NVIDIA-Linux-x86_64-450.51.run) |
-| 450.51.05 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/450.51.05/NVIDIA-Linux-x86_64-450.51.05.run) |
-| 450.51.06 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/450.51.06/NVIDIA-Linux-x86_64-450.51.06.run) |
-| 450.56.01 | YES | YES |  |
-| 450.56.02 | YES | YES |  |
-| 450.56.06 | YES | YES |  |
-| 450.56.11 | YES | YES |  |
-| 450.57 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.57/NVIDIA-Linux-x86_64-450.57.run) |
-| 450.66 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.66/NVIDIA-Linux-x86_64-450.66.run) |
-| 450.80.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.80.02/NVIDIA-Linux-x86_64-450.80.02.run) |
-| 450.102.04 | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.102.04/NVIDIA-Linux-x86_64-450.102.04.run) |
-| 455.22.04 | YES | NO |  |
-| 455.23.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.23.04/NVIDIA-Linux-x86_64-455.23.04.run) |
-| 455.23.05 | YES | YES |  |
-| 455.26.01 | YES | YES |  |
-| 455.26.02 | YES | YES |  |
-| 455.28 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.28/NVIDIA-Linux-x86_64-455.28.run) |
-| 455.32.00 | YES | YES |  |
-| 455.38 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.38/NVIDIA-Linux-x86_64-455.38.run) |
-| 455.45.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.45.01/NVIDIA-Linux-x86_64-455.45.01.run) |
-| 455.46.01 | YES | YES |  |
-| 455.46.02 | YES | YES |  |
-| 455.46.04 | YES | YES |  |
-| 455.50.02 | YES | YES |  |
-| 455.50.03 | NO | YES |  |
-| 455.50.04 | YES | YES |  |
-| 455.50.05 | YES | YES |  |
-| 455.50.07 | YES | YES |  |
-| 455.50.10 | YES | YES |  |
-| 460.27.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run) |
-| 460.32.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run) |
-| 460.39 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.39/NVIDIA-Linux-x86_64-460.39.run) |
-| 460.56 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.56/NVIDIA-Linux-x86_64-460.56.run) |
-| 460.67 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.67/NVIDIA-Linux-x86_64-460.67.run) |
-| 460.73.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.73.01/NVIDIA-Linux-x86_64-460.73.01.run) |
-| 460.80 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.80/NVIDIA-Linux-x86_64-460.80.run) |
-| 460.84 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.84/NVIDIA-Linux-x86_64-460.84.run) |
-| 460.91.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.91.03/NVIDIA-Linux-x86_64-460.91.03.run) |
-| 465.19.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.19.01/NVIDIA-Linux-x86_64-465.19.01.run) |
-| 465.24.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.24.02/NVIDIA-Linux-x86_64-465.24.02.run) |
-| 465.27 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.27/NVIDIA-Linux-x86_64-465.27.run) |
-| 465.31 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.31/NVIDIA-Linux-x86_64-465.31.run) |
-| 470.42.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.42.01/NVIDIA-Linux-x86_64-470.42.01.run) |
-| 470.57.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.57.02/NVIDIA-Linux-x86_64-470.57.02.run) |
-| 470.62.02 | YES | YES |  |
-| 470.62.05 | YES | YES |  |
-| 470.63.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.63.01/NVIDIA-Linux-x86_64-470.63.01.run) |
-| 470.74 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.74/NVIDIA-Linux-x86_64-470.74.run) |
-| 470.82.00 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.82.00/NVIDIA-Linux-x86_64-470.82.00.run) |
-| 470.82.01 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/470.82.01/NVIDIA-Linux-x86_64-470.82.01.run) |
-| 470.86 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.86/NVIDIA-Linux-x86_64-470.86.run) |
-| 470.94 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.94/NVIDIA-Linux-x86_64-470.94.run) |
-| 470.103.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.103.01/NVIDIA-Linux-x86_64-470.103.01.run) |
-| 470.129.06 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.129.06/NVIDIA-Linux-x86_64-470.129.06.run) |
-| 470.141.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.141.03/NVIDIA-Linux-x86_64-470.141.03.run) |
-| 470.161.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.161.03/NVIDIA-Linux-x86_64-470.161.03.run) |
-| 470.182.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.182.03/NVIDIA-Linux-x86_64-470.182.03.run) |
-| 470.199.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.199.02/NVIDIA-Linux-x86_64-470.199.02.run) |
-| 470.223.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.223.02/NVIDIA-Linux-x86_64-470.223.02.run) |
-| 470.239.06 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.239.06/NVIDIA-Linux-x86_64-470.239.06.run) |
-| 470.256.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/470.256.02/NVIDIA-Linux-x86_64-470.256.02.run) |
-| 495.29.05 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.29.05/NVIDIA-Linux-x86_64-495.29.05.run) |
-| 495.44 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.44/NVIDIA-Linux-x86_64-495.44.run) |
-| 495.46 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.46/NVIDIA-Linux-x86_64-495.46.run) |
-| 510.39.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.39.01/NVIDIA-Linux-x86_64-510.39.01.run) |
-| 510.47.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.47.03/NVIDIA-Linux-x86_64-510.47.03.run) |
-| 510.54 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.54/NVIDIA-Linux-x86_64-510.54.run) |
-| 510.60.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run) |
-| 510.68.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.68.02/NVIDIA-Linux-x86_64-510.68.02.run) |
-| 510.73.05 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.05/NVIDIA-Linux-x86_64-510.73.05.run) |
-| 510.73.08 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.08/NVIDIA-Linux-x86_64-510.73.08.run) |
-| 510.85.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run) |
-| 510.108.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.108.03/NVIDIA-Linux-x86_64-510.108.03.run) |
-| 515.43.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.43.04/NVIDIA-Linux-x86_64-515.43.04.run) |
-| 515.48.07 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/515.48.07/NVIDIA-Linux-x86_64-515.48.07.run) |
-| 515.57 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.57/NVIDIA-Linux-x86_64-515.57.run) |
-| 515.65.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.65.01/NVIDIA-Linux-x86_64-515.65.01.run) |
-| 515.76 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.76/NVIDIA-Linux-x86_64-515.76.run) |
-| 515.86.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.86.01/NVIDIA-Linux-x86_64-515.86.01.run) |
-| 515.105.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.105.01/NVIDIA-Linux-x86_64-515.105.01.run) |
-| 520.56.06 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/520.56.06/NVIDIA-Linux-x86_64-520.56.06.run) |
-| 520.61.05 | YES | YES | [Driver link](https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run) |
-| 525.60.11 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/525.60.11/NVIDIA-Linux-x86_64-525.60.11.run) |
-| 525.60.13 | YES | YES |  |
-| 525.78.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.78.01/NVIDIA-Linux-x86_64-525.78.01.run) |
-| 525.85.05 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.85.05/NVIDIA-Linux-x86_64-525.85.05.run) |
-| 525.85.12 | YES | YES |  |
-| 525.89.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.89.02/NVIDIA-Linux-x86_64-525.89.02.run) |
-| 525.105.17 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.105.17/NVIDIA-Linux-x86_64-525.105.17.run) |
-| 525.116.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.03/NVIDIA-Linux-x86_64-525.116.03.run) |
-| 525.116.04 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.04/NVIDIA-Linux-x86_64-525.116.04.run) |
-| 525.125.06 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.125.06/NVIDIA-Linux-x86_64-525.125.06.run) |
-| 525.147.05 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.147.05/NVIDIA-Linux-x86_64-525.147.05.run) |
-| 530.30.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/530.30.02/NVIDIA-Linux-x86_64-530.30.02.run) |
-| 530.41.03 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/530.41.03/NVIDIA-Linux-x86_64-530.41.03.run) |
-| 535.43.02 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.43.02/NVIDIA-Linux-x86_64-535.43.02.run) |
-| 535.43.25 | YES | YES | [Driver link](https://developer.nvidia.com/downloads/vulkan-beta-5354325-linux) |
-| 535.54.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.54.03/NVIDIA-Linux-x86_64-535.54.03.run) |
-| 535.86.05 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.86.05/NVIDIA-Linux-x86_64-535.86.05.run) |
-| 535.86.10 | YES | YES |  |
-| 535.98 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.98/NVIDIA-Linux-x86_64-535.98.run) |
-| 535.104.05 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.104.05/NVIDIA-Linux-x86_64-535.104.05.run) |
-| 535.104.12 | YES | YES | [Driver link](https://international.download.nvidia.com/tesla/535.104.12/NVIDIA-Linux-x86_64-535.104.12.run) |
-| 535.113.01 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.113.01/NVIDIA-Linux-x86_64-535.113.01.run) |
-| 535.129.03 | YES | YES | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run) |
-| 535.146.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.146.02/NVIDIA-Linux-x86_64-535.146.02.run) |
-| 535.154.05 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.154.05/NVIDIA-Linux-x86_64-535.154.05.run) |
-| 535.161.07 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run) |
-| 535.161.08 | YES | YES |  |
-| 535.171.04 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.171.04/NVIDIA-Linux-x86_64-535.171.04.run) |
-| 535.183.01 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run) |
-| 535.183.06 | YES | YES | [Driver link](http://international.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-x86_64-535.183.06.run) |
-| 545.23.06 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.23.06/NVIDIA-Linux-x86_64-545.23.06.run) |
-| 545.23.08 | YES | YES |  |
-| 545.29.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.02/NVIDIA-Linux-x86_64-545.29.02.run) |
-| 545.29.06 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.06/NVIDIA-Linux-x86_64-545.29.06.run) |
-| 550.40.07 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.40.07/NVIDIA-Linux-x86_64-550.40.07.run) |
-| 550.54.14 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.54.14/NVIDIA-Linux-x86_64-550.54.14.run) |
-| 550.54.15 | YES | YES |  |
-| 550.67 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.67/NVIDIA-Linux-x86_64-550.67.run) |
-| 550.76 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.76/NVIDIA-Linux-x86_64-550.76.run) |
-| 550.78 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.78/NVIDIA-Linux-x86_64-550.78.run) |
-| 550.90.07 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.90.07/NVIDIA-Linux-x86_64-550.90.07.run) |
-| 550.100 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.100/NVIDIA-Linux-x86_64-550.100.run) |
-| 550.107.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.107.02/NVIDIA-Linux-x86_64-550.107.02.run) |
-| 550.120 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.120/NVIDIA-Linux-x86_64-550.120.run) |
-| 550.127.05 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.127.05/NVIDIA-Linux-x86_64-550.127.05.run) |
-| 550.135 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.135/NVIDIA-Linux-x86_64-550.135.run) |
-| 555.42.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.42.02/NVIDIA-Linux-x86_64-555.42.02.run) |
-| 555.58 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58/NVIDIA-Linux-x86_64-555.58.run) |
-| 555.58.02 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58.02/NVIDIA-Linux-x86_64-555.58.02.run) |
-| 560.28.03 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/560.28.03/NVIDIA-Linux-x86_64-560.28.03.run) |
-| 560.35.03 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/560.35.03/NVIDIA-Linux-x86_64-560.35.03.run) |
-| 565.57.01 | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/565.57.01/NVIDIA-Linux-x86_64-565.57.01.run) |
+| Version | NVENC patch | NVFBC patch | NV_VK patch | Driver link |
+| :---    |    :---:    |    :---:    |    :---:    |    :---:    |
+| 375.39 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run) |
+| 390.77 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/390.77/NVIDIA-Linux-x86_64-390.77.run) |
+| 390.87 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/390.87/NVIDIA-Linux-x86_64-390.87.run) |
+| 390.147 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/390.147/NVIDIA-Linux-x86_64-390.147.run) |
+| 396.24 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/396.24/NVIDIA-Linux-x86_64-396.24.run) |
+| 396.26 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/396.26/NVIDIA-Linux-x86_64-396.26.run) |
+| 396.37 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run) |
+| 396.54 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/396.54/NVIDIA-Linux-x86_64-396.54.run) |
+| 410.48 | YES | NO | NO |  |
+| 410.57 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.57/NVIDIA-Linux-x86_64-410.57.run) |
+| 410.73 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.73/NVIDIA-Linux-x86_64-410.73.run) |
+| 410.78 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run) |
+| 410.79 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/410.79/NVIDIA-Linux-x86_64-410.79.run) |
+| 410.93 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/410.93/NVIDIA-Linux-x86_64-410.93.run) |
+| 410.104 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/410.104/NVIDIA-Linux-x86_64-410.104.run) |
+| 415.18 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.18/NVIDIA-Linux-x86_64-415.18.run) |
+| 415.25 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.25/NVIDIA-Linux-x86_64-415.25.run) |
+| 415.27 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/415.27/NVIDIA-Linux-x86_64-415.27.run) |
+| 418.30 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.30/NVIDIA-Linux-x86_64-418.30.run) |
+| 418.43 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.43/NVIDIA-Linux-x86_64-418.43.run) |
+| 418.56 | YES | NO | NO | [Driver link](https://download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run) |
+| 418.67 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run) |
+| 418.74 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.74/NVIDIA-Linux-x86_64-418.74.run) |
+| 418.87.00 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run) |
+| 418.87.01 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.01.run) |
+| 418.88 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.88/NVIDIA-Linux-x86_64-418.88.run) |
+| 418.113 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/418.113/NVIDIA-Linux-x86_64-418.113.run) |
+| 430.09 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.09/NVIDIA-Linux-x86_64-430.09.run) |
+| 430.14 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.14/NVIDIA-Linux-x86_64-430.14.run) |
+| 430.26 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.26/NVIDIA-Linux-x86_64-430.26.run) |
+| 430.34 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.34/NVIDIA-Linux-x86_64-430.34.run) |
+| 430.40 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.40/NVIDIA-Linux-x86_64-430.40.run) |
+| 430.50 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.50/NVIDIA-Linux-x86_64-430.50.run) |
+| 430.64 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/430.64/NVIDIA-Linux-x86_64-430.64.run) |
+| 435.17 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/435.17/NVIDIA-Linux-x86_64-435.17.run) |
+| 435.21 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/435.21/NVIDIA-Linux-x86_64-435.21.run) |
+| 440.26 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.26/NVIDIA-Linux-x86_64-440.26.run) |
+| 440.31 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.31/NVIDIA-Linux-x86_64-440.31.run) |
+| 440.33.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run) |
+| 440.36 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.36/NVIDIA-Linux-x86_64-440.36.run) |
+| 440.43.01 | YES | YES | NO |  |
+| 440.44 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.44/NVIDIA-Linux-x86_64-440.44.run) |
+| 440.48.02 | YES | YES | NO |  |
+| 440.58.01 | YES | YES | NO |  |
+| 440.58.02 | YES | YES | NO |  |
+| 440.59 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.59/NVIDIA-Linux-x86_64-440.59.run) |
+| 440.64 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.64/NVIDIA-Linux-x86_64-440.64.run) |
+| 440.64.00 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/440.64.00/NVIDIA-Linux-x86_64-440.64.00.run) |
+| 440.66.02 | YES | YES | NO |  |
+| 440.66.03 | YES | YES | NO |  |
+| 440.66.04 | YES | YES | NO |  |
+| 440.66.08 | YES | YES | NO |  |
+| 440.66.09 | YES | YES | NO |  |
+| 440.66.11 | YES | YES | NO |  |
+| 440.66.12 | YES | YES | NO |  |
+| 440.66.14 | YES | YES | NO |  |
+| 440.66.15 | YES | YES | NO |  |
+| 440.66.17 | YES | YES | NO |  |
+| 440.82 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run) |
+| 440.95.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/440.95.01/NVIDIA-Linux-x86_64-440.95.01.run) |
+| 440.100 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/440.100/NVIDIA-Linux-x86_64-440.100.run) |
+| 440.118.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/440.118.02/NVIDIA-Linux-x86_64-440.118.02.run) |
+| 450.36.06 | YES | YES | NO | [Driver link](https://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_450.36.06_linux.run) |
+| 450.51 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.51/NVIDIA-Linux-x86_64-450.51.run) |
+| 450.51.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/450.51.05/NVIDIA-Linux-x86_64-450.51.05.run) |
+| 450.51.06 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/450.51.06/NVIDIA-Linux-x86_64-450.51.06.run) |
+| 450.56.01 | YES | YES | NO |  |
+| 450.56.02 | YES | YES | NO |  |
+| 450.56.06 | YES | YES | NO |  |
+| 450.56.11 | YES | YES | NO |  |
+| 450.57 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.57/NVIDIA-Linux-x86_64-450.57.run) |
+| 450.66 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.66/NVIDIA-Linux-x86_64-450.66.run) |
+| 450.80.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.80.02/NVIDIA-Linux-x86_64-450.80.02.run) |
+| 450.102.04 | YES | NO | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/450.102.04/NVIDIA-Linux-x86_64-450.102.04.run) |
+| 455.22.04 | YES | NO | NO |  |
+| 455.23.04 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.23.04/NVIDIA-Linux-x86_64-455.23.04.run) |
+| 455.23.05 | YES | YES | NO |  |
+| 455.26.01 | YES | YES | NO |  |
+| 455.26.02 | YES | YES | NO |  |
+| 455.28 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.28/NVIDIA-Linux-x86_64-455.28.run) |
+| 455.32.00 | YES | YES | NO |  |
+| 455.38 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.38/NVIDIA-Linux-x86_64-455.38.run) |
+| 455.45.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/455.45.01/NVIDIA-Linux-x86_64-455.45.01.run) |
+| 455.46.01 | YES | YES | NO |  |
+| 455.46.02 | YES | YES | NO |  |
+| 455.46.04 | YES | YES | NO |  |
+| 455.50.02 | YES | YES | NO |  |
+| 455.50.03 | NO | YES | NO |  |
+| 455.50.04 | YES | YES | NO |  |
+| 455.50.05 | YES | YES | NO |  |
+| 455.50.07 | YES | YES | NO |  |
+| 455.50.10 | YES | YES | NO |  |
+| 460.27.04 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run) |
+| 460.32.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run) |
+| 460.39 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.39/NVIDIA-Linux-x86_64-460.39.run) |
+| 460.56 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.56/NVIDIA-Linux-x86_64-460.56.run) |
+| 460.67 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.67/NVIDIA-Linux-x86_64-460.67.run) |
+| 460.73.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.73.01/NVIDIA-Linux-x86_64-460.73.01.run) |
+| 460.80 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.80/NVIDIA-Linux-x86_64-460.80.run) |
+| 460.84 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.84/NVIDIA-Linux-x86_64-460.84.run) |
+| 460.91.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/460.91.03/NVIDIA-Linux-x86_64-460.91.03.run) |
+| 465.19.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.19.01/NVIDIA-Linux-x86_64-465.19.01.run) |
+| 465.24.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.24.02/NVIDIA-Linux-x86_64-465.24.02.run) |
+| 465.27 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.27/NVIDIA-Linux-x86_64-465.27.run) |
+| 465.31 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/465.31/NVIDIA-Linux-x86_64-465.31.run) |
+| 470.42.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.42.01/NVIDIA-Linux-x86_64-470.42.01.run) |
+| 470.57.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.57.02/NVIDIA-Linux-x86_64-470.57.02.run) |
+| 470.62.02 | YES | YES | NO |  |
+| 470.62.05 | YES | YES | NO |  |
+| 470.63.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.63.01/NVIDIA-Linux-x86_64-470.63.01.run) |
+| 470.74 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.74/NVIDIA-Linux-x86_64-470.74.run) |
+| 470.82.00 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.82.00/NVIDIA-Linux-x86_64-470.82.00.run) |
+| 470.82.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/470.82.01/NVIDIA-Linux-x86_64-470.82.01.run) |
+| 470.86 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.86/NVIDIA-Linux-x86_64-470.86.run) |
+| 470.94 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.94/NVIDIA-Linux-x86_64-470.94.run) |
+| 470.103.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.103.01/NVIDIA-Linux-x86_64-470.103.01.run) |
+| 470.129.06 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.129.06/NVIDIA-Linux-x86_64-470.129.06.run) |
+| 470.141.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.141.03/NVIDIA-Linux-x86_64-470.141.03.run) |
+| 470.161.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.161.03/NVIDIA-Linux-x86_64-470.161.03.run) |
+| 470.182.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.182.03/NVIDIA-Linux-x86_64-470.182.03.run) |
+| 470.199.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.199.02/NVIDIA-Linux-x86_64-470.199.02.run) |
+| 470.223.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.223.02/NVIDIA-Linux-x86_64-470.223.02.run) |
+| 470.239.06 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/470.239.06/NVIDIA-Linux-x86_64-470.239.06.run) |
+| 470.256.02 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/470.256.02/NVIDIA-Linux-x86_64-470.256.02.run) |
+| 495.29.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.29.05/NVIDIA-Linux-x86_64-495.29.05.run) |
+| 495.44 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.44/NVIDIA-Linux-x86_64-495.44.run) |
+| 495.46 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/495.46/NVIDIA-Linux-x86_64-495.46.run) |
+| 510.39.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.39.01/NVIDIA-Linux-x86_64-510.39.01.run) |
+| 510.47.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.47.03/NVIDIA-Linux-x86_64-510.47.03.run) |
+| 510.54 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.54/NVIDIA-Linux-x86_64-510.54.run) |
+| 510.60.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run) |
+| 510.68.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.68.02/NVIDIA-Linux-x86_64-510.68.02.run) |
+| 510.73.05 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.05/NVIDIA-Linux-x86_64-510.73.05.run) |
+| 510.73.08 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.08/NVIDIA-Linux-x86_64-510.73.08.run) |
+| 510.85.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run) |
+| 510.108.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/510.108.03/NVIDIA-Linux-x86_64-510.108.03.run) |
+| 515.43.04 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.43.04/NVIDIA-Linux-x86_64-515.43.04.run) |
+| 515.48.07 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/515.48.07/NVIDIA-Linux-x86_64-515.48.07.run) |
+| 515.57 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.57/NVIDIA-Linux-x86_64-515.57.run) |
+| 515.65.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.65.01/NVIDIA-Linux-x86_64-515.65.01.run) |
+| 515.76 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.76/NVIDIA-Linux-x86_64-515.76.run) |
+| 515.86.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.86.01/NVIDIA-Linux-x86_64-515.86.01.run) |
+| 515.105.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/515.105.01/NVIDIA-Linux-x86_64-515.105.01.run) |
+| 520.56.06 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/520.56.06/NVIDIA-Linux-x86_64-520.56.06.run) |
+| 520.61.05 | YES | YES | NO | [Driver link](https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run) |
+| 525.60.11 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/525.60.11/NVIDIA-Linux-x86_64-525.60.11.run) |
+| 525.60.13 | YES | YES | NO |  |
+| 525.78.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.78.01/NVIDIA-Linux-x86_64-525.78.01.run) |
+| 525.85.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.85.05/NVIDIA-Linux-x86_64-525.85.05.run) |
+| 525.85.12 | YES | YES | NO |  |
+| 525.89.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.89.02/NVIDIA-Linux-x86_64-525.89.02.run) |
+| 525.105.17 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.105.17/NVIDIA-Linux-x86_64-525.105.17.run) |
+| 525.116.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.03/NVIDIA-Linux-x86_64-525.116.03.run) |
+| 525.116.04 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.04/NVIDIA-Linux-x86_64-525.116.04.run) |
+| 525.125.06 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.125.06/NVIDIA-Linux-x86_64-525.125.06.run) |
+| 525.147.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/525.147.05/NVIDIA-Linux-x86_64-525.147.05.run) |
+| 530.30.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/530.30.02/NVIDIA-Linux-x86_64-530.30.02.run) |
+| 530.41.03 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/530.41.03/NVIDIA-Linux-x86_64-530.41.03.run) |
+| 535.43.02 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.43.02/NVIDIA-Linux-x86_64-535.43.02.run) |
+| 535.43.25 | YES | YES | NO | [Driver link](https://developer.nvidia.com/downloads/vulkan-beta-5354325-linux) |
+| 535.54.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.54.03/NVIDIA-Linux-x86_64-535.54.03.run) |
+| 535.86.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.86.05/NVIDIA-Linux-x86_64-535.86.05.run) |
+| 535.86.10 | YES | YES | NO |  |
+| 535.98 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.98/NVIDIA-Linux-x86_64-535.98.run) |
+| 535.104.05 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.104.05/NVIDIA-Linux-x86_64-535.104.05.run) |
+| 535.104.12 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/tesla/535.104.12/NVIDIA-Linux-x86_64-535.104.12.run) |
+| 535.113.01 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.113.01/NVIDIA-Linux-x86_64-535.113.01.run) |
+| 535.129.03 | YES | YES | NO | [Driver link](https://international.download.nvidia.com/XFree86/Linux-x86_64/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run) |
+| 535.146.02 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.146.02/NVIDIA-Linux-x86_64-535.146.02.run) |
+| 535.154.05 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.154.05/NVIDIA-Linux-x86_64-535.154.05.run) |
+| 535.161.07 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run) |
+| 535.161.08 | YES | YES | NO |  |
+| 535.171.04 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.171.04/NVIDIA-Linux-x86_64-535.171.04.run) |
+| 535.183.01 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run) |
+| 535.183.06 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-x86_64-535.183.06.run) |
+| 545.23.06 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.23.06/NVIDIA-Linux-x86_64-545.23.06.run) |
+| 545.23.08 | YES | YES | NO |  |
+| 545.29.02 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.02/NVIDIA-Linux-x86_64-545.29.02.run) |
+| 545.29.06 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.06/NVIDIA-Linux-x86_64-545.29.06.run) |
+| 550.40.07 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.40.07/NVIDIA-Linux-x86_64-550.40.07.run) |
+| 550.54.14 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.54.14/NVIDIA-Linux-x86_64-550.54.14.run) |
+| 550.54.15 | YES | YES | NO |  |
+| 550.67 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.67/NVIDIA-Linux-x86_64-550.67.run) |
+| 550.76 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.76/NVIDIA-Linux-x86_64-550.76.run) |
+| 550.78 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.78/NVIDIA-Linux-x86_64-550.78.run) |
+| 550.90.07 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.90.07/NVIDIA-Linux-x86_64-550.90.07.run) |
+| 550.100 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.100/NVIDIA-Linux-x86_64-550.100.run) |
+| 550.107.02 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.107.02/NVIDIA-Linux-x86_64-550.107.02.run) |
+| 550.120 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.120/NVIDIA-Linux-x86_64-550.120.run) |
+| 550.127.05 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.127.05/NVIDIA-Linux-x86_64-550.127.05.run) |
+| 550.135 | YES | YES | NO | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/550.135/NVIDIA-Linux-x86_64-550.135.run) |
+| 555.42.02 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.42.02/NVIDIA-Linux-x86_64-555.42.02.run) |
+| 555.58 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58/NVIDIA-Linux-x86_64-555.58.run) |
+| 555.58.02 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58.02/NVIDIA-Linux-x86_64-555.58.02.run) |
+| 560.28.03 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/560.28.03/NVIDIA-Linux-x86_64-560.28.03.run) |
+| 560.35.03 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/560.35.03/NVIDIA-Linux-x86_64-560.35.03.run) |
+| 565.57.01 | YES | YES | YES | [Driver link](http://international.download.nvidia.com/XFree86/Linux-x86_64/565.57.01/NVIDIA-Linux-x86_64-565.57.01.run) |
 
 ## Synopsis
 
@@ -266,7 +268,26 @@ DESCRIPTION
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
        -f             Enable support for Flatpak NVIDIA drivers.
+```
 
+```
+# bash ./patch-vk.sh -h
+
+SYNOPSIS
+       patch-vk.sh [-s] [-r|-h|-c VERSION|-l|-f]
+
+DESCRIPTION
+       The patch for Nvidia vulkan drivers to remove NVENC session limit
+
+       -s             Silent mode (No output)
+       -r             Rollback to original (Restore lib from backup)
+       -h             Print this help message
+       -c VERSION     Check if version VERSION supported by this patch.
+                      Returns true exit code (0) if version is supported.
+       -l             List supported driver versions
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
+       -j             Output the patch list to stdout as JSON
 ```
 
 ## Step-by-Step guide

--- a/drivers.json
+++ b/drivers.json
@@ -6,1144 +6,1341 @@
                     "version": "375.39",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run"
                 },
                 {
                     "version": "390.77",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/390.77/NVIDIA-Linux-x86_64-390.77.run"
                 },
                 {
                     "version": "390.87",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/390.87/NVIDIA-Linux-x86_64-390.87.run"
                 },
                 {
                     "version": "396.24",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/396.24/NVIDIA-Linux-x86_64-396.24.run"
                 },
                 {
                     "version": "396.26",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/396.26/NVIDIA-Linux-x86_64-396.26.run"
                 },
                 {
                     "version": "396.37",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run"
                 },
                 {
                     "version": "396.54",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/396.54/NVIDIA-Linux-x86_64-396.54.run"
                 },
                 {
                     "version": "410.48",
                     "nvenc_patch": true,
-                    "nvfbc_patch": false
+                    "nvfbc_patch": false,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "410.57",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.57/NVIDIA-Linux-x86_64-410.57.run"
                 },
                 {
                     "version": "410.73",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.73/NVIDIA-Linux-x86_64-410.73.run"
                 },
                 {
                     "version": "410.78",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.78/NVIDIA-Linux-x86_64-410.78.run"
                 },
                 {
                     "version": "410.79",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/410.79/NVIDIA-Linux-x86_64-410.79.run"
                 },
                 {
                     "version": "410.93",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/410.93/NVIDIA-Linux-x86_64-410.93.run"
                 },
                 {
                     "version": "410.104",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/410.104/NVIDIA-Linux-x86_64-410.104.run"
                 },
                 {
                     "version": "415.18",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/415.18/NVIDIA-Linux-x86_64-415.18.run"
                 },
                 {
                     "version": "415.25",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/415.25/NVIDIA-Linux-x86_64-415.25.run"
                 },
                 {
                     "version": "415.27",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/415.27/NVIDIA-Linux-x86_64-415.27.run"
                 },
                 {
                     "version": "418.30",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/418.30/NVIDIA-Linux-x86_64-418.30.run"
                 },
                 {
                     "version": "418.43",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/418.43/NVIDIA-Linux-x86_64-418.43.run"
                 },
                 {
                     "version": "418.56",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run"
                 },
                 {
                     "version": "418.67",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run"
                 },
                 {
                     "version": "418.74",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/418.74/NVIDIA-Linux-x86_64-418.74.run"
                 },
                 {
                     "version": "418.87.00",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run"
                 },
                 {
                     "version": "418.87.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.01.run"
                 },
                 {
                     "version": "418.88",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/418.88/NVIDIA-Linux-x86_64-418.88.run"
                 },
                 {
                     "version": "430.09",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.09/NVIDIA-Linux-x86_64-430.09.run"
                 },
                 {
                     "version": "430.14",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.14/NVIDIA-Linux-x86_64-430.14.run"
                 },
                 {
                     "version": "430.26",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.26/NVIDIA-Linux-x86_64-430.26.run"
                 },
                 {
                     "version": "430.34",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.34/NVIDIA-Linux-x86_64-430.34.run"
                 },
                 {
                     "version": "430.40",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.40/NVIDIA-Linux-x86_64-430.40.run"
                 },
                 {
                     "version": "430.50",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.50/NVIDIA-Linux-x86_64-430.50.run"
                 },
                 {
                     "version": "435.17",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/435.17/NVIDIA-Linux-x86_64-435.17.run"
                 },
                 {
                     "version": "435.21",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/435.21/NVIDIA-Linux-x86_64-435.21.run"
                 },
                 {
                     "version": "440.26",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.26/NVIDIA-Linux-x86_64-440.26.run"
                 },
                 {
                     "version": "440.31",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.31/NVIDIA-Linux-x86_64-440.31.run"
                 },
                 {
                     "version": "440.33.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run"
                 },
                 {
                     "version": "440.36",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.36/NVIDIA-Linux-x86_64-440.36.run"
                 },
                 {
                     "version": "440.44",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.44/NVIDIA-Linux-x86_64-440.44.run"
                 },
                 {
                     "version": "440.43.01",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "430.64",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/430.64/NVIDIA-Linux-x86_64-430.64.run"
                 },
                 {
                     "version": "440.48.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.59",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.59/NVIDIA-Linux-x86_64-440.59.run"
                 },
                 {
                     "version": "440.58.01",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.58.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.64",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.64/NVIDIA-Linux-x86_64-440.64.run"
                 },
                 {
                     "version": "440.64.00",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/440.64.00/NVIDIA-Linux-x86_64-440.64.00.run"
                 },
                 {
                     "version": "440.66.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.03",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.04",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.08",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.82",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.82/NVIDIA-Linux-x86_64-440.82.run"
                 },
                 {
                     "version": "440.66.09",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.11",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "418.113",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/418.113/NVIDIA-Linux-x86_64-418.113.run"
                 },
                 {
                     "version": "440.66.12",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.14",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.66.15",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.36.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_450.36.06_linux.run"
                 },
                 {
                     "version": "440.66.17",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "440.95.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/440.95.01/NVIDIA-Linux-x86_64-440.95.01.run"
                 },
                 {
                     "version": "450.51",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.51/NVIDIA-Linux-x86_64-450.51.run"
                 },
                 {
                     "version": "440.100",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/440.100/NVIDIA-Linux-x86_64-440.100.run"
                 },
                 {
                     "version": "440.118.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/440.118.02/NVIDIA-Linux-x86_64-440.118.02.run"
                 },
                 {
                     "version": "450.51.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/450.51.05/NVIDIA-Linux-x86_64-450.51.05.run"
                 },
                 {
                     "version": "450.57",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.57/NVIDIA-Linux-x86_64-450.57.run"
                 },
                 {
                     "version": "450.56.01",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.56.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.51.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/450.51.06/NVIDIA-Linux-x86_64-450.51.06.run"
                 },
                 {
                     "version": "450.56.06",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.66",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.66/NVIDIA-Linux-x86_64-450.66.run"
                 },
                 {
                     "version": "455.23.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/455.23.04/NVIDIA-Linux-x86_64-455.23.04.run"
                 },
                 {
                     "version": "450.56.11",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.23.05",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.80.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.80.02/NVIDIA-Linux-x86_64-450.80.02.run"
                 },
                 {
                     "version": "455.22.04",
                     "nvenc_patch": true,
-                    "nvfbc_patch": false
+                    "nvfbc_patch": false,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.28",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/455.28/NVIDIA-Linux-x86_64-455.28.run"
                 },
                 {
                     "version": "455.26.01",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.26.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.38",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/455.38/NVIDIA-Linux-x86_64-455.38.run"
                 },
                 {
                     "version": "455.32.00",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.45.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/455.45.01/NVIDIA-Linux-x86_64-455.45.01.run"
                 },
                 {
                     "version": "455.46.01",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.46.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.46.04",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "450.102.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/450.102.04/NVIDIA-Linux-x86_64-450.102.04.run"
                 },
                 {
                     "version": "460.27.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.27.04/NVIDIA-Linux-x86_64-460.27.04.run"
                 },
                 {
                     "version": "460.32.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.32.03/NVIDIA-Linux-x86_64-460.32.03.run"
                 },
                 {
                     "version": "460.39",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.39/NVIDIA-Linux-x86_64-460.39.run"
                 },
                 {
                     "version": "455.50.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.50.03",
                     "nvenc_patch": false,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.50.04",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.50.05",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "455.50.07",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "460.56",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.56/NVIDIA-Linux-x86_64-460.56.run"
                 },
                 {
                     "version": "455.50.10",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "460.67",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.67/NVIDIA-Linux-x86_64-460.67.run"
                 },
                 {
                     "version": "465.19.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/465.19.01/NVIDIA-Linux-x86_64-465.19.01.run"
                 },
                 {
                     "version": "465.24.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/465.24.02/NVIDIA-Linux-x86_64-465.24.02.run"
                 },
                 {
                     "version": "460.73.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.73.01/NVIDIA-Linux-x86_64-460.73.01.run"
                 },
                 {
                     "version": "465.27",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/465.27/NVIDIA-Linux-x86_64-465.27.run"
                 },
                 {
                     "version": "460.80",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.80/NVIDIA-Linux-x86_64-460.80.run"
                 },
                 {
                     "version": "465.31",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/465.31/NVIDIA-Linux-x86_64-465.31.run"
                 },
                 {
                     "version": "460.84",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.84/NVIDIA-Linux-x86_64-460.84.run"
                 },
                 {
                     "version": "470.42.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.42.01/NVIDIA-Linux-x86_64-470.42.01.run"
                 },
                 {
                     "version": "470.57.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.57.02/NVIDIA-Linux-x86_64-470.57.02.run"
                 },
                 {
                     "version": "460.91.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/460.91.03/NVIDIA-Linux-x86_64-460.91.03.run"
                 },
                 {
                     "version": "470.63.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.63.01/NVIDIA-Linux-x86_64-470.63.01.run"
                 },
                 {
                     "version": "470.62.02",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "470.74",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.74/NVIDIA-Linux-x86_64-470.74.run"
                 },
                 {
                     "version": "470.82.00",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.82.00/NVIDIA-Linux-x86_64-470.82.00.run"
                 },
                 {
                     "version": "470.62.05",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "470.86",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.86/NVIDIA-Linux-x86_64-470.86.run"
                 },
                 {
                     "version": "495.29.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/495.29.05/NVIDIA-Linux-x86_64-495.29.05.run"
                 },
                 {
                     "version": "495.44",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/495.44/NVIDIA-Linux-x86_64-495.44.run"
                 },
                 {
                     "version": "495.46",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/495.46/NVIDIA-Linux-x86_64-495.46.run"
                 },
                 {
                     "version": "470.82.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/470.82.01/NVIDIA-Linux-x86_64-470.82.01.run"
                 },
                 {
                     "version": "470.94",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.94/NVIDIA-Linux-x86_64-470.94.run"
                 },
                 {
                     "version": "470.103.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.103.01/NVIDIA-Linux-x86_64-470.103.01.run"
                 },
                 {
                     "version": "470.129.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.129.06/NVIDIA-Linux-x86_64-470.129.06.run"
                 },
                 {
                     "version": "470.141.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.141.03/NVIDIA-Linux-x86_64-470.141.03.run"
                 },
                 {
                     "version": "470.161.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.161.03/NVIDIA-Linux-x86_64-470.161.03.run"
                 },
                 {
                     "version": "470.182.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.182.03/NVIDIA-Linux-x86_64-470.182.03.run"
                 },
                 {
                     "version": "470.199.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.199.02/NVIDIA-Linux-x86_64-470.199.02.run"
                 },
                 {
                     "version": "470.223.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.223.02/NVIDIA-Linux-x86_64-470.223.02.run"
                 },
                 {
                     "version": "470.239.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/470.239.06/NVIDIA-Linux-x86_64-470.239.06.run"
                 },
                 {
                     "version": "510.39.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.39.01/NVIDIA-Linux-x86_64-510.39.01.run"
                 },
                 {
                     "version": "510.47.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.47.03/NVIDIA-Linux-x86_64-510.47.03.run"
                 },
                 {
                     "version": "510.54",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.54/NVIDIA-Linux-x86_64-510.54.run"
                 },
                 {
                     "version": "390.147",
                     "nvenc_patch": true,
                     "nvfbc_patch": false,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/390.147/NVIDIA-Linux-x86_64-390.147.run"
                 },
                 {
                     "version": "510.60.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.60.02/NVIDIA-Linux-x86_64-510.60.02.run"
                 },
                 {
                     "version": "510.68.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.68.02/NVIDIA-Linux-x86_64-510.68.02.run"
                 },
                 {
                     "version": "515.43.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.43.04/NVIDIA-Linux-x86_64-515.43.04.run"
                 },
                 {
                     "version": "510.73.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.05/NVIDIA-Linux-x86_64-510.73.05.run"
                 },
                 {
                     "version": "515.48.07",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/515.48.07/NVIDIA-Linux-x86_64-515.48.07.run"
                 },
                 {
                     "version": "510.73.08",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.73.08/NVIDIA-Linux-x86_64-510.73.08.run"
                 },
                 {
                     "version": "510.85.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.85.02/NVIDIA-Linux-x86_64-510.85.02.run"
                 },
                 {
                     "version": "510.108.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/510.108.03/NVIDIA-Linux-x86_64-510.108.03.run"
                 },
                 {
                     "version": "515.57",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.57/NVIDIA-Linux-x86_64-515.57.run"
                 },
                 {
                     "version": "515.65.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.65.01/NVIDIA-Linux-x86_64-515.65.01.run"
                 },
                 {
                     "version": "515.76",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.76/NVIDIA-Linux-x86_64-515.76.run"
                 },
                 {
                     "version": "515.86.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.86.01/NVIDIA-Linux-x86_64-515.86.01.run"
                 },
                 {
                     "version": "520.56.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/520.56.06/NVIDIA-Linux-x86_64-520.56.06.run"
                 },
                 {
                     "version": "520.61.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
                 },
                 {
                     "version": "525.60.11",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/525.60.11/NVIDIA-Linux-x86_64-525.60.11.run"
                 },
                 {
                     "version": "525.60.13",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "525.78.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.78.01/NVIDIA-Linux-x86_64-525.78.01.run"
                 },
                 {
                     "version": "525.85.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.85.05/NVIDIA-Linux-x86_64-525.85.05.run"
                 },
                 {
                     "version": "525.85.12",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "525.89.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.89.02/NVIDIA-Linux-x86_64-525.89.02.run"
                 },
                 {
                     "version": "525.105.17",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.105.17/NVIDIA-Linux-x86_64-525.105.17.run"
                 },
                 {
                     "version": "525.147.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.147.05/NVIDIA-Linux-x86_64-525.147.05.run"
                 },
                 {
                     "version": "530.30.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/530.30.02/NVIDIA-Linux-x86_64-530.30.02.run"
                 },
                 {
                     "version": "530.41.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/530.41.03/NVIDIA-Linux-x86_64-530.41.03.run"
                 },
                 {
                     "version": "515.105.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/515.105.01/NVIDIA-Linux-x86_64-515.105.01.run"
                 },
                 {
                     "version": "525.116.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.03/NVIDIA-Linux-x86_64-525.116.03.run"
                 },
                 {
                     "version": "535.43.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.43.02/NVIDIA-Linux-x86_64-535.43.02.run"
                 },
                 {
                     "version": "525.116.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.116.04/NVIDIA-Linux-x86_64-525.116.04.run"
                 },
                 {
                     "version": "535.54.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.54.03/NVIDIA-Linux-x86_64-535.54.03.run"
                 },
                 {
                     "version": "525.125.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/525.125.06/NVIDIA-Linux-x86_64-525.125.06.run"
                 },
                 {
                     "version": "535.86.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.86.05/NVIDIA-Linux-x86_64-535.86.05.run"
                 },
                 {
                     "version": "535.98",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.98/NVIDIA-Linux-x86_64-535.98.run"
                 },
                 {
                     "version": "535.86.10",
                     "nvenc_patch": true,
-                    "nvfbc_patch": true
+                    "nvfbc_patch": true,
+                    "nvvk_patch": false
                 },
                 {
                     "version": "535.104.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.104.05/NVIDIA-Linux-x86_64-535.104.05.run"
                 },
                 {
                     "version": "535.113.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.113.01/NVIDIA-Linux-x86_64-535.113.01.run"
                 },
                 {
                     "version": "535.104.12",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/tesla/535.104.12/NVIDIA-Linux-x86_64-535.104.12.run"
                 },
                 {
                     "version": "535.129.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://international.download.nvidia.com/XFree86/Linux-x86_64/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run"
                 },
                 {
                     "version": "545.23.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/545.23.06/NVIDIA-Linux-x86_64-545.23.06.run"
                 },
                 {
                     "version": "545.23.08",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": ""
                 },
                 {
                     "version": "545.29.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.02/NVIDIA-Linux-x86_64-545.29.02.run"
                 },
                 {
                     "version": "545.29.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/545.29.06/NVIDIA-Linux-x86_64-545.29.06.run"
                 },
                 {
                     "version": "535.146.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/535.146.02/NVIDIA-Linux-x86_64-535.146.02.run"
                 },
                 {
                     "version": "535.154.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/535.154.05/NVIDIA-Linux-x86_64-535.154.05.run"
                 },
                 {
                     "version": "550.40.07",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.40.07/NVIDIA-Linux-x86_64-550.40.07.run"
                 },
                 {
                     "version": "535.43.25",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "https://developer.nvidia.com/downloads/vulkan-beta-5354325-linux"
                 },
                 {
                     "version": "550.54.14",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.54.14/NVIDIA-Linux-x86_64-550.54.14.run"
                 },
                 {
                     "version": "550.54.15",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": ""
                 },
                 {
                     "version": "535.161.07",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/535.161.07/NVIDIA-Linux-x86_64-535.161.07.run"
                 },
                 {
                     "version": "535.161.08",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": ""
                 },
                 {
                     "version": "550.67",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.67/NVIDIA-Linux-x86_64-550.67.run"
                 },
                 {
                     "version": "550.76",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.76/NVIDIA-Linux-x86_64-550.76.run"
                 },
                 {
                     "version": "550.78",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.78/NVIDIA-Linux-x86_64-550.78.run"
                 },
                 {
                     "version": "535.171.04",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/535.171.04/NVIDIA-Linux-x86_64-535.171.04.run"
                 },
                 {
                     "version": "555.42.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/555.42.02/NVIDIA-Linux-x86_64-555.42.02.run"
                 },
                 {
                     "version": "470.256.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/470.256.02/NVIDIA-Linux-x86_64-470.256.02.run"
                 },
                 {
                     "version": "550.90.07",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.90.07/NVIDIA-Linux-x86_64-550.90.07.run"
                 },
                 {
                     "version": "535.183.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run"
                 },
                 {
                     "version": "535.183.06",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-x86_64-535.183.06.run"
                 },
                 {
                     "version": "555.58",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58/NVIDIA-Linux-x86_64-555.58.run"
                 },
                 {
                     "version": "555.58.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/555.58.02/NVIDIA-Linux-x86_64-555.58.02.run"
                 },
                 {
                     "version": "550.100",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.100/NVIDIA-Linux-x86_64-550.100.run"
                 },
                 {
                     "version": "550.107.02",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.107.02/NVIDIA-Linux-x86_64-550.107.02.run"
                 },
                 {
                     "version": "560.28.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/560.28.03/NVIDIA-Linux-x86_64-560.28.03.run"
                 },
                 {
                     "version": "560.35.03",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/560.35.03/NVIDIA-Linux-x86_64-560.35.03.run"
                 },
                 {
                     "version": "550.120",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.120/NVIDIA-Linux-x86_64-550.120.run"
                 },
                 {
                     "version": "565.57.01",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": true,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/565.57.01/NVIDIA-Linux-x86_64-565.57.01.run"
                 },
                 {
                     "version": "550.127.05",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.127.05/NVIDIA-Linux-x86_64-550.127.05.run"
                 },
                 {
                     "version": "550.135",
                     "nvenc_patch": true,
                     "nvfbc_patch": true,
+                    "nvvk_patch": false,
                     "driver_url": "http://international.download.nvidia.com/XFree86/Linux-x86_64/550.135/NVIDIA-Linux-x86_64-550.135.run"
                 }
             ],

--- a/patch-vk.sh
+++ b/patch-vk.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# halt on any error for safety and proper pipe handling
+set -euo pipefail ; # <- this semicolon and comment make options apply
+# even when script is corrupt by CRLF line terminators (issue #75)
+# empty line must follow this comment for immediate fail with CRLF newlines
+
+# root check
+if [ "$(id -u)" -ne 0 ]; then
+  echo
+  echo -e "Please run as root!"
+  echo
+  exit 1
+fi
+
+
+backup_path="/opt/nvidia/libnvidia-eglcore-backup"
+silent_flag=''
+manual_driver_version=''
+flatpak_flag=''
+backup_suffix=''
+
+print_usage() { printf '
+SYNOPSIS
+       patch-vk.sh [-s] [-r|-h|-c VERSION|-l|-f]
+
+DESCRIPTION
+       The patch for Nvidia vulkan drivers to remove NVENC session limit
+
+       -s             Silent mode (No output)
+       -r             Rollback to original (Restore lib from backup)
+       -h             Print this help message
+       -c VERSION     Check if version VERSION supported by this patch.
+                      Returns true exit code (0) if version is supported.
+       -l             List supported driver versions
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
+       -j             Output the patch list to stdout as JSON
+'
+}
+
+# shellcheck disable=SC2209
+opmode="patch"
+
+while getopts 'rshjc:ld:' flag; do
+    case "${flag}" in
+        r) opmode="${opmode}rollback" ;;
+        s) silent_flag='true' ;;
+        h) opmode="${opmode}help" ;;
+        c) opmode="${opmode}checkversion" ; checked_version="$OPTARG" ;;
+        l) opmode="${opmode}listversions" ;;
+        d) manual_driver_version="$OPTARG" ;;
+        j) opmode="dump" ;;
+        *) echo "Incorrect option specified in command line" ; exit 2 ;;
+    esac
+done
+
+if [[ $silent_flag ]]; then
+    exec 1> /dev/null
+fi
+
+if [[ $flatpak_flag ]]; then
+    backup_suffix='.flatpak'
+    echo "WARNING: Flatpak flag enabled (-f), modifying ONLY the Flatpak driver."
+fi
+
+declare -A patch_list=(
+    ["555.42.02"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+    ["555.58"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+    ["555.58.02"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+    ["560.35.03"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+    ["560.28.03"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+    ["565.57.01"]='s/\x53\x89\xf3\x41\xb9\x04\x00\x00\x00\x48\x83\xec\x10/\x48\xc7\xc0\x01\x00\x00\x00\xc3\xc3\xc3\xc3\xc3\xc3/g'
+)
+
+check_version_supported () {
+    local ver="$1"
+    [[ "${patch_list[$ver]+isset}" ]]
+}
+
+# get_flatpak_driver_path () {
+#     # Flatpak's package versioning replaces '.' by '-'
+#     version="$(echo "$1" | tr '.' '-')"
+#     # Attempts to patch system flatpak
+#     if path=$(flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-${version}" 2>/dev/null); then
+#         echo "$path/files/lib"
+#     # If it isn't found will login as the user that envoked sudo & patch this version
+#     elif path=$(su -c - ${SUDO_USER} 'flatpak info --show-location "org.freedesktop.Platform.GL.nvidia-'${version}'"'); then
+#         echo "$path/files/lib"
+#     fi
+# }
+
+get_supported_versions () {
+    for drv in "${!patch_list[@]}"; do
+        echo "$drv"
+    done | sort -t. -n
+    return 0
+}
+
+patch_common () {
+    NVIDIA_SMI="$(command -v nvidia-smi || true)"
+    if [[ ! "$NVIDIA_SMI" ]] ; then
+        echo 'nvidia-smi utility not found. Probably driver is not installed.'
+        exit 1
+    fi
+
+    if [[ "$manual_driver_version" ]]; then
+        driver_version="$manual_driver_version"
+
+        echo "Using manually entered nvidia driver version: $driver_version"
+    else
+        cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
+        driver_versions_list=$($cmd) || (
+            ret_code=$?
+            echo "Can not detect nvidia driver version."
+            echo "CMD: \"$cmd\""
+            echo "Result: \"$driver_versions_list\""
+            echo "nvidia-smi retcode: $ret_code"
+            exit 1
+        )
+        driver_version=$(echo "$driver_versions_list" | head -n 1)
+
+        echo "Detected nvidia driver version: $driver_version"
+    fi
+
+    if ! check_version_supported "$driver_version" ; then
+        echo "Patch for this ($driver_version) nvidia driver not found."
+        echo "Patch is available for versions: "
+        get_supported_versions
+        exit 1
+    fi
+
+    patch="${patch_list[$driver_version]}"
+    driver_maj_version=${driver_version%%.*}
+    object='libnvidia-eglcore.so'
+    echo $object
+
+    # if [[ $flatpak_flag ]]; then
+    #     driver_dir=$(get_flatpak_driver_path "$driver_version")
+    #     if [ -z "$driver_dir" ]; then
+    #         echo "ERROR: Flatpak package for driver $driver_version does not appear to be installed."
+    #         echo "Try rebooting your computer and/or running 'flatpak update'."
+    #         exit 1
+    #     fi
+    #     # return early because the code below is out of scope for the Flatpak driver
+    #     return 0
+    # fi
+
+    declare -a driver_locations=(
+        '/usr/lib/x86_64-linux-gnu'
+        '/usr/lib/x86_64-linux-gnu/nvidia/current/'
+        '/usr/lib/x86_64-linux-gnu/nvidia/tesla/'
+        "/usr/lib/x86_64-linux-gnu/nvidia/tesla-${driver_version%%.*}/"
+        '/usr/lib64'
+        '/usr/lib'
+        "/usr/lib/nvidia-${driver_version%%.*}"
+    )
+
+    dir_found=''
+    for driver_dir in "${driver_locations[@]}" ; do
+        if [[ -e "$driver_dir/$object.$driver_version" ]]; then
+            dir_found='true'
+            break
+        fi
+    done
+
+    [[ "$dir_found" ]] || { echo "ERROR: cannot detect driver directory"; exit 1; }
+
+}
+
+ensure_bytes_are_valid () {
+    driver_file="$driver_dir/$object.$driver_version"
+    original_bytes=$(awk -F / '$2 { print $2 }' <<< "$patch")
+    patched_bytes=$(awk -F / '$3 { print $3 }' <<< "$patch")
+    if LC_ALL=C grep -qaP "$original_bytes" "$driver_file"; then
+        printf "Bytes to patch: %s\n" "$original_bytes"
+        return 0 # file is ready to be patched
+    fi
+    if LC_ALL=C grep -qaP "$patched_bytes" "$driver_file"; then
+        echo "Warn: Bytes '$patched_bytes' already present in '$driver_file'."
+        return 0 # file is likely patched already
+    fi
+    echo "Error: Could not find bytes '$original_bytes' to patch in '$driver_file'."
+    exit 1
+}
+
+rollback () {
+    patch_common
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        cp -p "$backup_path/$object.$driver_version$backup_suffix" \
+           "$driver_dir/$object.$driver_version"
+        echo "Restore from backup $object.$driver_version$backup_suffix"
+    else
+        echo "Backup not found. Try to patch first."
+        exit 1
+    fi
+}
+
+patch () {
+    patch_common
+    ensure_bytes_are_valid
+    if [[ -f "$backup_path/$object.$driver_version$backup_suffix" ]]; then
+        bkp_hash="$(sha1sum "$backup_path/$object.$driver_version$backup_suffix" | cut -f1 -d\ )"
+        drv_hash="$(sha1sum "$driver_dir/$object.$driver_version" | cut -f1 -d\ )"
+        if [[ "$bkp_hash" != "$drv_hash" ]] ; then
+            echo "Backup exists and driver file differ from backup. Skipping patch."
+            return 0
+        fi
+    else
+        echo "Attention! Backup not found. Copying current $object to backup."
+        mkdir -p "$backup_path"
+        cp -p "$driver_dir/$object.$driver_version" \
+           "$backup_path/$object.$driver_version$backup_suffix"
+    fi
+    sha1sum "$backup_path/$object.$driver_version$backup_suffix"
+    sed "$patch" "$backup_path/$object.$driver_version$backup_suffix" > \
+      "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
+    sha1sum "${PATCH_OUTPUT_DIR-$driver_dir}/$object.$driver_version"
+    ldconfig
+    echo "Patched!"
+}
+
+query_version_support () {
+    if check_version_supported "$checked_version" ; then
+        echo "SUPPORTED"
+        exit 0
+    else
+        echo "NOT SUPPORTED"
+        exit 1
+    fi
+}
+
+list_supported_versions () {
+    get_supported_versions
+}
+
+dump_patches () {
+    for i in "${!patch_list[@]}"
+    do
+        echo "$i"
+        echo "${patch_list[$i]}"
+    done |
+    jq --sort-keys -n -R 'reduce inputs as $i ({}; . + { ($i): (input|(tonumber? // .)) })'
+}
+
+case "${opmode}" in
+    patch) patch ;;
+    patchrollback) rollback ;;
+    patchhelp) print_usage ; exit 2 ;;
+    patchcheckversion) query_version_support ;;
+    patchlistversions) list_supported_versions ;;
+    dump) dump_patches ;;
+    *) echo "Incorrect combination of flags. Use option -h to get help."
+       exit 2 ;;
+esac

--- a/tools/autopatch/update_patch.sh
+++ b/tools/autopatch/update_patch.sh
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
     Update the patch for Nvidia NVENC or NVFBC drivers for a new version
 
-    -f PATCH_FILE               The file (patch.sh/patch-fbc.sh) that should be updated
+    -f PATCH_FILE               The file (patch.sh/patch-fbc.sh/patch-vk.sh) that should be updated
     -v VERSION                  Driver version (by default copies latest existing patch)
     -o OLD_VERSION              Copy patch string from this older driver version
     -b PATCHSTR                 Append PATCHSTR to the patch_list

--- a/tools/readme-autogen/readme_autogen.py
+++ b/tools/readme-autogen/readme_autogen.py
@@ -38,9 +38,11 @@ def linux_readme(data):
                 driver_link = ''
             nvenc_patch = md_true if drv['nvenc_patch'] else md_false
             nvfbc_patch = md_true if drv['nvfbc_patch'] else md_false
+            nvvk_patch = md_true if drv['nvvk_patch'] else md_false
             yield row_tmpl.substitute(version=drv['version'],
                                       nvenc_patch=nvenc_patch,
                                       nvfbc_patch=nvfbc_patch,
+                                      nvvk_patch=nvvk_patch,
                                       driver_link=driver_link)
     version_list = "\n".join(row_gen())
     latest_version = drivers[-1]['version']

--- a/tools/readme-autogen/templates/linux_driver_row.tmpl
+++ b/tools/readme-autogen/templates/linux_driver_row.tmpl
@@ -1,1 +1,1 @@
-| $version | $nvenc_patch | $nvfbc_patch | $driver_link |
+| $version | $nvenc_patch | $nvfbc_patch | $nvvk_patch | $driver_link |

--- a/tools/readme-autogen/templates/linux_readme_master.tmpl
+++ b/tools/readme-autogen/templates/linux_readme_master.tmpl
@@ -7,6 +7,8 @@ NVENC and NvFBC patches for Nvidia drivers
 
 [NvFBC patch](patch-fbc.sh) allows to use NvFBC on consumer-grade GPUs. It should be applied same way as NVENC `patch.sh`, except you have to use `patch-fbc.sh` instead.
 
+[Vulkan Patch](patch-vk.sh) removes restriction on maximum number of simultaneous Vulkan video encoding sessions imposed by Nvidia to consumer-grade GPUs, this is similar to [NVENC patch](patch.sh) but for Vulkan API.
+
 Main target operating system is **GNU/Linux**, but for **Windows** support see [**win** (clickable)](win).
 
 ---
@@ -25,8 +27,8 @@ If you want to donate, please send it to your favorite open source organizations
 
 ## Version Table
 
-| Version | NVENC patch | NVFBC patch | Driver link |
-| :---    |    :---:    |    :---:    |        ---: |
+| Version | NVENC patch | NVFBC patch | NV_VK patch | Driver link |
+| :---    |    :---:    |    :---:    |    :---:    |    :---:    |
 $version_list
 
 ## Synopsis
@@ -70,7 +72,26 @@ DESCRIPTION
        -d VERSION     Use VERSION driver version when looking for libraries
                       instead of using nvidia-smi to detect it.
        -f             Enable support for Flatpak NVIDIA drivers.
+```
 
+```
+# bash ./patch-vk.sh -h
+
+SYNOPSIS
+       patch-vk.sh [-s] [-r|-h|-c VERSION|-l|-f]
+
+DESCRIPTION
+       The patch for Nvidia vulkan drivers to remove NVENC session limit
+
+       -s             Silent mode (No output)
+       -r             Rollback to original (Restore lib from backup)
+       -h             Print this help message
+       -c VERSION     Check if version VERSION supported by this patch.
+                      Returns true exit code (0) if version is supported.
+       -l             List supported driver versions
+       -d VERSION     Use VERSION driver version when looking for libraries
+                      instead of using nvidia-smi to detect it.
+       -j             Output the patch list to stdout as JSON
 ```
 
 ## Step-by-Step guide


### PR DESCRIPTION
**Purpose of proposed changes**

Vulkan recently added [Video Encoding API](https://www.khronos.org/blog/khronos-finalizes-vulkan-video-extensions-for-accelerated-h.264-and-h.265-encode) Nvidia, and AMD started implementing support for this.

And for Nvidia cards, similar to NVENC API, there is a limit to consumer grade cards.

This PR adds a new patch script `patch-vk` to patch `libnvidia-eglcore.so` which contain the functionality controlling the encoding session and its restrictions.

In this PR as well I added patch support for versions from `555.42.02` to `565.57.01` (all use the same patch, so other versions might also be patched).

**Essential steps taken**

Check 35d33fb0 for details on the patch itself, but to summarize.

The function doing the restriction is `0xD7E780` (address in version 555.58.02).
 The function signature is like this
```C
// This is C++, but for `C` translation it will be something like this
bool auth_release(void* this, bool is_auth);
```
It will take either `is_auth==true` if in `auth` or `false` when releasing.
    
It will return either `true` for success or `false` for failure.
    
What we changed here is that we replaced this function implementation with just `return true;`.

So it won't do increment or decrement the "usage" counters


