### PR TITLE
nvidia-smi check despite manual version input

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -285,16 +285,18 @@ get_supported_versions () {
 }
 
 patch_common () {
+ if [[ "$manual_driver_version" ]]; then
+        driver_version="$manual_driver_version"
+        
+        echo "Using manually entered Nvidia driver version: $driver_version"
+    else
+    
     NVIDIA_SMI="$(command -v nvidia-smi || true)"
+    
     if [[ ! "$NVIDIA_SMI" ]] ; then
         echo 'nvidia-smi utility not found. Probably driver is not installed.'
         exit 1
-    fi
-
-    if [[ "$manual_driver_version" ]]; then
-        driver_version="$manual_driver_version"
-
-        echo "Using manually entered nvidia driver version: $driver_version"
+    
     else
         cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
         driver_versions_list=$($cmd) || (
@@ -308,7 +310,8 @@ patch_common () {
         driver_version=$(echo "$driver_versions_list" | head -n 1)
 
         echo "Detected nvidia driver version: $driver_version"
-    fi
+       
+       fi
 
     if ! check_version_supported "$driver_version" ; then
         echo "Patch for this ($driver_version) nvidia driver not found."

--- a/patch.sh
+++ b/patch.sh
@@ -285,18 +285,17 @@ get_supported_versions () {
 }
 
 patch_common () {
- if [[ "$manual_driver_version" ]]; then
+    if [[ "$manual_driver_version" ]]; then
         driver_version="$manual_driver_version"
-        
-        echo "Using manually entered Nvidia driver version: $driver_version"
-    else
-    
+
+        echo "Using manually entered nvidia driver version: $driver_version"
+     fi
+     
+       else
     NVIDIA_SMI="$(command -v nvidia-smi || true)"
-    
     if [[ ! "$NVIDIA_SMI" ]] ; then
         echo 'nvidia-smi utility not found. Probably driver is not installed.'
         exit 1
-    
     else
         cmd="$NVIDIA_SMI --query-gpu=driver_version --format=csv,noheader,nounits"
         driver_versions_list=$($cmd) || (
@@ -310,8 +309,7 @@ patch_common () {
         driver_version=$(echo "$driver_versions_list" | head -n 1)
 
         echo "Detected nvidia driver version: $driver_version"
-       
-       fi
+    fi
 
     if ! check_version_supported "$driver_version" ; then
         echo "Patch for this ($driver_version) nvidia driver not found."


### PR DESCRIPTION
**Purpose of proposed changes**

nvidia-smi is still being called when -d is being used. -d should allow skipping nvidia-smi since you're manually telling the patcher which driver version is being used. If a manual version is submitted, then nvidia-smi check should be skipped.

**Essential steps taken**

All I did was move manual version check ahead of nvidia-smi check, and skipped the nvidia-smi check if the manual version was submitted.


For context; my Linux system is Batocera, by it's nature it's very minimal and as such nvidia-smi is not included (despite updated drivers).
