### PR TITLE
win: hotfix - Update drivers.json

### DIFF
--- a/drivers.json
+++ b/drivers.json
@@ -4835,7 +4835,7 @@
                     "patch64_url": "win10_x64/580.88/nvencodeapi64.1337",
                     "patch32_url": "win10_x64/580.88/nvencodeapi.1337",
                     "driver_url": "https://international.download.nvidia.com/Windows/580.88/580.88-desktop-win10-win11-64bit-international-dch-whql.exe"
-                ,
+                },
                 {
                     "os": "win10",
                     "product": "GeForce",


### PR DESCRIPTION
Broken json format, missing closing bracket "}" at line #4811. Also fixes NVCleanstall error.

**Purpose of proposed changes**

Fixes the broken format of the json.
Fixes NVCleanstall error.