### PR TITLE
docs: fix 'paramater' typo in Flatpak restore section

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ bash ./patch.sh -f
 bash ./patch-fbc.sh -f
 ```
 
-In case something goes wrong, you can restore the original Flatpak drivers by adding the `-r` paramater:
+In case something goes wrong, you can restore the original Flatpak drivers by adding the `-r` parameter:
 
 ```
 bash ./patch.sh -f -r

--- a/tools/readme-autogen/templates/linux_readme_master.tmpl
+++ b/tools/readme-autogen/templates/linux_readme_master.tmpl
@@ -139,7 +139,7 @@ bash ./patch.sh -f
 bash ./patch-fbc.sh -f
 ```
 
-In case something goes wrong, you can restore the original Flatpak drivers by adding the `-r` paramater:
+In case something goes wrong, you can restore the original Flatpak drivers by adding the `-r` parameter:
 
 ```
 bash ./patch.sh -f -r


### PR DESCRIPTION
## Summary
Fixes a spelling typo when documenting the Flatpak restore flag: `paramater` → `parameter`.

## Test plan
- [ ] Confirm the Flatpak restore instructions still read correctly

Made with [Cursor](https://cursor.com)