### PR TITLE
win: fix patch-tester

### DIFF
--- a/win/tools/patch-tester/patch-tester.bat
+++ b/win/tools/patch-tester/patch-tester.bat
@@ -1,6 +1,6 @@
 @echo off
 
-ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -t 50 -i testsrc2 ^
+ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc2=d=150 ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - ^

--- a/win/tools/patch-tester/patch-tester.bat
+++ b/win/tools/patch-tester/patch-tester.bat
@@ -1,6 +1,6 @@
 @echo off
 
-ffmpeg.exe -y -init_hw_device cuda -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 ^
+ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -t 50 -i testsrc2 ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - ^

--- a/win/tools/patch-tester/patch-tester.bat
+++ b/win/tools/patch-tester/patch-tester.bat
@@ -1,6 +1,6 @@
 @echo off
 
-ffmpeg.exe -y -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 ^
+ffmpeg.exe -y -init_hw_device cuda -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - ^
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - ^

--- a/win/tools/patch-tester/patch-tester.ps1
+++ b/win/tools/patch-tester/patch-tester.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -t 50 -i testsrc2 `
+ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc2=d=150 `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - `

--- a/win/tools/patch-tester/patch-tester.ps1
+++ b/win/tools/patch-tester/patch-tester.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-ffmpeg.exe -y -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 `
+ffmpeg.exe -y -init_hw_device cuda -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - `

--- a/win/tools/patch-tester/patch-tester.ps1
+++ b/win/tools/patch-tester/patch-tester.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-ffmpeg.exe -y -init_hw_device cuda -hwaccel cuda -hwaccel_output_format cuda -f lavfi -i testsrc -t 50 `
+ffmpeg.exe -y -init_hw_device cuda:0 -hwaccel cuda -hwaccel_output_format cuda -f lavfi -t 50 -i testsrc2 `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 1M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 2M  -f null - `
 -vf hwupload -fps_mode passthrough -c:a copy -c:v h264_nvenc -b:v 3M  -f null - `


### PR DESCRIPTION
Current command doesn't work. This error is always returned:
```ps1
[hwupload @ 000001f89307f4c0] A hardware device reference is required to upload frames to.
[AVFilterGraph @ 000001f89303f380] Error initializing filters
Error opening output file -.
```

Updated ffmpeg command as per documentation [ffmpeg.org hwaccel -init_hw_device](https://ffmpeg.org/ffmpeg.html#Advanced-Video-options:~:text=%2Dinit_hw_device).
Fixes #892, fixes #1070